### PR TITLE
refactor: rename library from @and-subscribe to @tayori

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# stripe-webhook-router
+# Tayori
+
+A Hono-inspired, type-safe Stripe webhook routing library for TypeScript.

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "and-subscribe",
+  "name": "tayori",
   "version": "0.0.0",
   "private": true,
-  "description": "A Hono-like API for Stripe Webhook event routing",
+  "description": "A Hono-inspired type-safe Stripe Webhook routing library",
   "type": "module",
   "scripts": {
     "test": "pnpm -r test",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@and-subscribe/core",
+  "name": "@tayori/core",
   "version": "0.1.0",
   "description": "Core routing logic for Stripe Webhook events",
   "type": "module",

--- a/packages/eventbridge/package.json
+++ b/packages/eventbridge/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@and-subscribe/eventbridge",
+  "name": "@tayori/eventbridge",
   "version": "0.1.0",
   "description": "AWS EventBridge adapter for Stripe Webhook Router",
   "type": "module",
@@ -25,7 +25,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@and-subscribe/core": "workspace:*"
+    "@tayori/core": "workspace:*"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.159",

--- a/packages/eventbridge/src/index.ts
+++ b/packages/eventbridge/src/index.ts
@@ -1,5 +1,5 @@
 import type { EventBridgeEvent, Context } from 'aws-lambda';
-import type { WebhookRouter, WebhookEvent } from '@and-subscribe/core';
+import type { WebhookRouter, WebhookEvent } from '@tayori/core';
 
 /**
  * Options for the EventBridge adapter
@@ -45,4 +45,4 @@ export function eventBridgeAdapter<TEventMap extends Record<string, WebhookEvent
 }
 
 // Re-export core types
-export { WebhookRouter, type WebhookEvent, type EventHandler, type Middleware } from '@and-subscribe/core';
+export { WebhookRouter, type WebhookEvent, type EventHandler, type Middleware } from '@tayori/core';

--- a/packages/eventbridge/test/eventbridge-adapter.test.ts
+++ b/packages/eventbridge/test/eventbridge-adapter.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { EventBridgeEvent, Context } from 'aws-lambda';
 import { eventBridgeAdapter } from '../src/index.js';
-import { WebhookRouter } from '@and-subscribe/core';
+import { WebhookRouter } from '@tayori/core';
 
 describe('eventBridgeAdapter', () => {
   let mockContext: Context;

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@and-subscribe/express",
+  "name": "@tayori/express",
   "version": "0.1.0",
   "description": "Express adapter for Stripe Webhook Router",
   "type": "module",
@@ -25,7 +25,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@and-subscribe/core": "workspace:*"
+    "@tayori/core": "workspace:*"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, NextFunction } from 'express';
-import type { WebhookRouter, WebhookEvent } from '@and-subscribe/core';
+import type { WebhookRouter, WebhookEvent } from '@tayori/core';
 import type Stripe from 'stripe';
 
 /**
@@ -24,7 +24,7 @@ export interface ExpressAdapterOptions {
  * ```typescript
  * import express from 'express';
  * import Stripe from 'stripe';
- * import { expressAdapter } from '@and-subscribe/express';
+ * import { expressAdapter } from '@tayori/express';
  *
  * const stripe = new Stripe(process.env.STRIPE_API_KEY!);
  * const app = express();
@@ -103,4 +103,4 @@ export function expressAdapter<TEventMap extends Record<string, WebhookEvent>>(
 }
 
 // Re-export core types
-export { WebhookRouter, type WebhookEvent, type EventHandler, type Middleware } from '@and-subscribe/core';
+export { WebhookRouter, type WebhookEvent, type EventHandler, type Middleware } from '@tayori/core';

--- a/packages/express/test/express-adapter.test.ts
+++ b/packages/express/test/express-adapter.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Request, Response } from 'express';
 import { expressAdapter } from '../src/index.js';
-import { WebhookRouter } from '@and-subscribe/core';
+import { WebhookRouter } from '@tayori/core';
 import type Stripe from 'stripe';
 
 describe('expressAdapter', () => {

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@and-subscribe/hono",
+  "name": "@tayori/hono",
   "version": "0.1.0",
   "description": "Hono adapter for Stripe Webhook Router",
   "type": "module",
@@ -25,7 +25,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@and-subscribe/core": "workspace:*"
+    "@tayori/core": "workspace:*"
   },
   "devDependencies": {
     "hono": "^4.0.0",

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -1,5 +1,5 @@
 import type { Context } from 'hono';
-import type { WebhookRouter, WebhookEvent } from '@and-subscribe/core';
+import type { WebhookRouter, WebhookEvent } from '@tayori/core';
 import type Stripe from 'stripe';
 
 /**
@@ -24,7 +24,7 @@ export interface HonoAdapterOptions {
  * ```typescript
  * import { Hono } from 'hono';
  * import Stripe from 'stripe';
- * import { honoAdapter } from '@and-subscribe/hono';
+ * import { honoAdapter } from '@tayori/hono';
  *
  * const stripe = new Stripe(process.env.STRIPE_API_KEY!);
  * const router = new WebhookRouter();
@@ -96,4 +96,4 @@ export function honoAdapter<TEventMap extends Record<string, WebhookEvent>>(
 }
 
 // Re-export core types
-export { WebhookRouter, type WebhookEvent, type EventHandler, type Middleware } from '@and-subscribe/core';
+export { WebhookRouter, type WebhookEvent, type EventHandler, type Middleware } from '@tayori/core';

--- a/packages/hono/test/hono-adapter.test.ts
+++ b/packages/hono/test/hono-adapter.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 import { honoAdapter } from '../src/index.js';
-import { WebhookRouter } from '@and-subscribe/core';
+import { WebhookRouter } from '@tayori/core';
 import type Stripe from 'stripe';
 
 describe('honoAdapter', () => {

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@and-subscribe/lambda",
+  "name": "@tayori/lambda",
   "version": "0.1.0",
   "description": "AWS Lambda adapter for Stripe Webhook Router",
   "type": "module",
@@ -25,7 +25,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@and-subscribe/core": "workspace:*"
+    "@tayori/core": "workspace:*"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.159",

--- a/packages/lambda/src/index.ts
+++ b/packages/lambda/src/index.ts
@@ -1,5 +1,5 @@
 import type { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
-import type { WebhookRouter, WebhookEvent } from '@and-subscribe/core';
+import type { WebhookRouter, WebhookEvent } from '@tayori/core';
 import type Stripe from 'stripe';
 
 /**
@@ -24,7 +24,7 @@ export interface LambdaAdapterOptions {
  * @example
  * ```typescript
  * import Stripe from 'stripe';
- * import { lambdaAdapter } from '@and-subscribe/lambda';
+ * import { lambdaAdapter } from '@tayori/lambda';
  *
  * const stripe = new Stripe(process.env.STRIPE_API_KEY!);
  * const router = new WebhookRouter();
@@ -123,4 +123,4 @@ export function lambdaAdapter<TEventMap extends Record<string, WebhookEvent>>(
 }
 
 // Re-export core types
-export { WebhookRouter, type WebhookEvent, type EventHandler, type Middleware } from '@and-subscribe/core';
+export { WebhookRouter, type WebhookEvent, type EventHandler, type Middleware } from '@tayori/core';

--- a/packages/lambda/test/lambda-adapter.test.ts
+++ b/packages/lambda/test/lambda-adapter.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { APIGatewayProxyEvent, Context } from 'aws-lambda';
 import { lambdaAdapter } from '../src/index.js';
-import { WebhookRouter } from '@and-subscribe/core';
+import { WebhookRouter } from '@tayori/core';
 import type Stripe from 'stripe';
 
 describe('lambdaAdapter', () => {

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@and-subscribe/stripe",
+  "name": "@tayori/stripe",
   "version": "0.1.0",
   "description": "Stripe-specific type definitions and utilities",
   "type": "module",
@@ -26,7 +26,7 @@
     "check-events": "tsx scripts/check-events.ts"
   },
   "dependencies": {
-    "@and-subscribe/core": "workspace:*"
+    "@tayori/core": "workspace:*"
   },
   "devDependencies": {
     "stripe": "^20.0.0",

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -366,7 +366,7 @@ export type StripeEventType<T extends StripeEventName> = StripeEventMap[T];
 export type { Stripe };
 
 // Re-export core types and classes
-import { WebhookRouter, type WebhookEvent, type EventHandler } from '@and-subscribe/core';
+import { WebhookRouter, type WebhookEvent, type EventHandler } from '@tayori/core';
 export { WebhookRouter, type WebhookEvent, type EventHandler };
 
 /**


### PR DESCRIPTION
Renamed the library to "Tayori" (便り - message/notification in Japanese),
better reflecting its purpose as a Stripe webhook notification router.
This Hono-inspired library provides type-safe routing for Stripe webhooks.

Changes:
- Rename package scope from @and-subscribe to @tayori
- Update all package names and internal dependencies
- Update README with new library name and description
- Update all TypeScript imports across packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Rebranded the project from "and-subscribe" to "Tayori" with updated documentation and package names. All sub-packages have been renamed to @tayori/core, @tayori/express, @tayori/hono, @tayori/lambda, @tayori/stripe, and @tayori/eventbridge. Users upgrading should update their package dependencies accordingly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->