### PR TITLE
Add OpenTelemetry resource attributes configuration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,5 +23,8 @@
         ]
       }
     ]
+  },
+  "env": {
+    "OTEL_RESOURCE_ATTRIBUTES": "project.name=kotodayori"
   }
 }


### PR DESCRIPTION
## Summary
Added OpenTelemetry (OTEL) resource attributes configuration to the Claude settings file to enable proper project identification in telemetry data.

## Key Changes
- Added `env` configuration section to `.claude/settings.json`
- Set `OTEL_RESOURCE_ATTRIBUTES` environment variable with project name identifier `kotodayori`

## Implementation Details
This configuration enables OpenTelemetry instrumentation to properly tag all telemetry signals (traces, metrics, logs) with the project name, making it easier to identify and filter telemetry data from this specific project in observability platforms.

https://claude.ai/code/session_01FS78UsQ8kTJKJ8MB9upLNg