### PR TITLE
Add automatic language detection and redirect for Japanese users

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -15,6 +15,12 @@ export default defineConfig({
         root: { label: 'English', lang: 'en' },
         ja:   { label: '日本語',  lang: 'ja' },
       },
+      head: [
+        {
+          tag: 'script',
+          content: `(function(){try{if(localStorage.getItem('lang-preference'))return;var lang=(navigator.language||'').toLowerCase();var path=location.pathname;var isJa=/^\\/ja(\\/|$)/.test(path);var pref=lang.startsWith('ja')?'ja':'en';localStorage.setItem('lang-preference',pref);if(pref==='ja'&&!isJa){location.replace('/ja'+path);}}catch(e){}})();`,
+        },
+      ],
       plugins: [
         starlightChangelogs(),
         starlightLlmsTxt(),

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -18,7 +18,7 @@ export default defineConfig({
       head: [
         {
           tag: 'script',
-          content: `(function(){try{if(localStorage.getItem('lang-preference'))return;var lang=(navigator.language||'').toLowerCase();var path=location.pathname;var isJa=/^\\/ja(\\/|$)/.test(path);var pref=lang.startsWith('ja')?'ja':'en';localStorage.setItem('lang-preference',pref);if(pref==='ja'&&!isJa){location.replace('/ja'+path);}}catch(e){}})();`,
+          content: `(function(){try{if(localStorage.getItem('lang-preference'))return;var lang=(navigator.language||'').toLowerCase();var path=location.pathname;var isJa=/^\\/ja(\\/|$)/.test(path);var pref=lang.startsWith('ja')?'ja':'en';localStorage.setItem('lang-preference',pref);if(pref==='ja'&&!isJa){location.replace('/ja'+path+location.search+location.hash);}}catch(e){}})();`,
         },
       ],
       plugins: [


### PR DESCRIPTION
## Summary
This PR adds automatic language detection based on the user's browser language preference. When a user's browser language is set to Japanese, they are automatically redirected to the Japanese version of the site if they're not already viewing it.

## Key Changes
- Added a script to the document head that:
  - Detects the user's browser language preference via `navigator.language`
  - Checks if the current page path is already in the Japanese locale (`/ja`)
  - Automatically redirects Japanese-speaking users to the `/ja` version of the current page
  - Stores the language preference in `localStorage` to avoid repeated detection
  - Gracefully handles any errors to prevent breaking the page load

## Implementation Details
- The script runs immediately on page load before other content renders
- Uses a self-executing function to avoid polluting the global scope
- Includes error handling with try-catch to ensure robustness
- Only performs redirect if the user isn't already on the Japanese version of the page
- Stores preference in localStorage to respect user's initial language choice

https://claude.ai/code/session_01D3kQujaW9gKHpExWVaekwY