### PR TITLE
Upgrade Kotodayori packages to v1.0.0

### DIFF
--- a/packages/create-kotodayori/templates/eventbridge/package.json
+++ b/packages/create-kotodayori/templates/eventbridge/package.json
@@ -6,8 +6,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@kotodayori/eventbridge": "^0.1.0",
-    "@kotodayori/stripe": "^0.1.0",
+    "@kotodayori/eventbridge": "^1.0.0",
+    "@kotodayori/stripe": "^1.0.0",
     "stripe": "^18.5.0"
   },
   "devDependencies": {

--- a/packages/create-kotodayori/templates/express/package.json
+++ b/packages/create-kotodayori/templates/express/package.json
@@ -9,8 +9,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@kotodayori/express": "^0.1.0",
-    "@kotodayori/stripe": "^0.1.0",
+    "@kotodayori/express": "^1.0.0",
+    "@kotodayori/stripe": "^1.0.0",
     "express": "^4.18.2",
     "stripe": "^20.3.1"
   },

--- a/packages/create-kotodayori/templates/hono/package.json
+++ b/packages/create-kotodayori/templates/hono/package.json
@@ -9,8 +9,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@kotodayori/hono": "^0.1.0",
-    "@kotodayori/stripe": "^0.1.0",
+    "@kotodayori/hono": "^1.0.0",
+    "@kotodayori/stripe": "^1.0.0",
     "hono": "^4.0.0",
     "stripe": "^20.3.1"
   },

--- a/packages/create-kotodayori/templates/lambda/package.json
+++ b/packages/create-kotodayori/templates/lambda/package.json
@@ -6,8 +6,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@kotodayori/lambda": "^0.1.0",
-    "@kotodayori/stripe": "^0.1.0",
+    "@kotodayori/lambda": "^1.0.0",
+    "@kotodayori/stripe": "^1.0.0",
     "stripe": "^18.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
This PR updates all Kotodayori package dependencies across template configurations to version 1.0.0, marking the stable release of the framework.

## Changes
- Updated `@kotodayori/eventbridge` from `^0.1.0` to `^1.0.0` in eventbridge template
- Updated `@kotodayori/express` from `^0.1.0` to `^1.0.0` in express template
- Updated `@kotodayori/hono` from `^0.1.0` to `^1.0.0` in hono template
- Updated `@kotodayori/lambda` from `^0.1.0` to `^1.0.0` in lambda template
- Updated `@kotodayori/stripe` from `^0.1.0` to `^1.0.0` across all templates (eventbridge, express, hono, lambda)

## Details
All template package.json files have been updated to reference the stable v1.0.0 releases of the Kotodayori framework packages. This ensures that new projects created from these templates will use the latest stable versions of the framework.

https://claude.ai/code/session_01AiywERVB6cZRhb3EuyRRef