### PR TITLE
Improve type safety for group() and adapter generic inference

### DIFF
--- a/.changeset/type-safe-group-and-adapter-inference.md
+++ b/.changeset/type-safe-group-and-adapter-inference.md
@@ -1,0 +1,22 @@
+---
+"@kotodayori/core": minor
+"@kotodayori/hono": minor
+"@kotodayori/express": minor
+"@kotodayori/lambda": minor
+---
+
+Improve type inference and type safety across the router and adapters.
+
+- `WebhookRouter.group()` now preserves the parent router's event-map types.
+  Handlers registered via `group(prefix, ...).on(suffix, handler)` receive the
+  concrete event type for `prefix.suffix` (e.g. `Stripe.Subscription` for
+  `data.object`) instead of the previously erased `WebhookEvent` / `unknown`.
+  Invalid suffixes for a given prefix are now rejected at compile time.
+
+- The framework adapters (`honoAdapter`, `expressAdapter`, `lambdaAdapter`) now
+  infer the verifier's event type as an independent generic, decoupled from the
+  router's event map. A typed router (such as `StripeWebhookRouter`) is no
+  longer rejected when the verifier returns an event union that differs from the
+  router's map — for example when the installed Stripe SDK ships events that the
+  hand-maintained `StripeEventMap` does not yet include. This removes the need
+  for `as unknown as WebhookRouter` workarounds at the call site.

--- a/examples/sample-express-stripe/src/index.ts
+++ b/examples/sample-express-stripe/src/index.ts
@@ -3,7 +3,6 @@ import Stripe from 'stripe';
 import {
   StripeWebhookRouter,
   createStripeVerifier,
-  type StripeEventMap,
 } from '@kotodayori/stripe';
 import { expressAdapter } from '@kotodayori/express';
 import { paymentHandlers } from './handlers/payment.js';
@@ -55,7 +54,7 @@ app.get('/', (_req, res) => {
 app.post(
   '/webhook',
   express.raw({ type: 'application/json' }),
-  expressAdapter<StripeEventMap>(webhookRouter, {
+  expressAdapter(webhookRouter, {
     verifier: createStripeVerifier(stripe, process.env.STRIPE_WEBHOOK_SECRET),
     onError: async (error, event) => {
       console.error(`Failed to process ${event?.type}:`, error);

--- a/examples/sample-hono-stripe/src/index.ts
+++ b/examples/sample-hono-stripe/src/index.ts
@@ -3,7 +3,6 @@ import Stripe from 'stripe';
 import {
   StripeWebhookRouter,
   createStripeVerifier,
-  type StripeEventMap,
 } from '@kotodayori/stripe';
 import { honoAdapter } from '@kotodayori/hono';
 import { paymentHandlers } from './handlers/payment.js';
@@ -52,7 +51,7 @@ app.get('/', (c) => {
 
 app.post(
   '/webhook',
-  honoAdapter<StripeEventMap>(webhookRouter, {
+  honoAdapter(webhookRouter, {
     verifier: createStripeVerifier(stripe, process.env.STRIPE_WEBHOOK_SECRET),
     onError: async (error, event) => {
       console.error(`Failed to process ${event?.type}:`, error);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,23 @@ export interface WebhookEvent {
 export type DefaultEventMap = Record<string, WebhookEvent>;
 
 /**
+ * Extracts the valid event suffixes for a given prefix from an event map.
+ *
+ * For example, given a map with keys `customer.subscription.created` and
+ * `customer.subscription.deleted`, `EventSuffix<Map, 'customer.subscription'>`
+ * resolves to `'created' | 'deleted'`.
+ *
+ * For the default (open) event map this resolves to `string`, preserving the
+ * previous loosely-typed behaviour.
+ */
+export type EventSuffix<
+  TEventMap,
+  TPrefix extends string,
+> = Extract<keyof TEventMap, `${TPrefix}.${string}`> extends `${TPrefix}.${infer TSuffix}`
+  ? TSuffix
+  : never;
+
+/**
  * Event handler function type
  */
 export type EventHandler<T extends WebhookEvent> = (event: T) => Promise<void>;
@@ -182,16 +199,16 @@ export class WebhookRouter<
    * @param callback - Function that receives a prefixed router
    * @returns this for chaining
    */
-  group(prefix: string, callback: (router: PrefixedRouter) => void): this {
+  group<TPrefix extends string>(
+    prefix: TPrefix,
+    callback: (router: PrefixedRouter<TEventMap, TPrefix>) => void
+  ): this {
     // Reject empty prefix
     if (prefix.trim() === '') {
       throw new Error('Group prefix cannot be an empty string or whitespace');
     }
 
-    const prefixedRouter = new PrefixedRouter(
-      prefix,
-      this as unknown as WebhookRouter<Record<string, WebhookEvent>>
-    );
+    const prefixedRouter = new PrefixedRouter<TEventMap, TPrefix>(prefix, this);
     callback(prefixedRouter);
     return this;
   }
@@ -279,26 +296,38 @@ export class WebhookRouter<
 
 /**
  * Helper class for group() syntax that adds prefix to event types
+ *
+ * @typeParam TEventMap - The parent router's event map
+ * @typeParam TPrefix - The event type prefix this group is scoped to
  */
-class PrefixedRouter {
+class PrefixedRouter<
+  TEventMap extends Record<string, WebhookEvent> = DefaultEventMap,
+  TPrefix extends string = string,
+> {
   constructor(
-    private prefix: string,
-    private parent: WebhookRouter<Record<string, WebhookEvent>>
+    private prefix: TPrefix,
+    private parent: WebhookRouter<TEventMap>
   ) {}
 
   /**
    * Register a handler for a single event type (with prefix)
    */
-  on(event: string, handler: EventHandler<WebhookEvent>): this;
+  on<TSuffix extends EventSuffix<TEventMap, TPrefix>>(
+    event: TSuffix,
+    handler: EventHandler<TEventMap[`${TPrefix}.${TSuffix}` & keyof TEventMap]>
+  ): this;
 
   /**
    * Register a handler for multiple event types (with prefix)
    */
-  on(events: string[], handler: EventHandler<WebhookEvent>): this;
+  on<TSuffix extends EventSuffix<TEventMap, TPrefix>>(
+    events: TSuffix[],
+    handler: EventHandler<TEventMap[`${TPrefix}.${TSuffix}` & keyof TEventMap]>
+  ): this;
 
   on(
     eventOrEvents: string | string[],
-    handler: EventHandler<WebhookEvent>
+    handler: EventHandler<never>
   ): this {
     const events = Array.isArray(eventOrEvents) ? eventOrEvents : [eventOrEvents];
 
@@ -308,13 +337,18 @@ class PrefixedRouter {
       return this;
     }
 
+    // The parent is strongly typed, but the prefixed event name is only known
+    // to be a valid key at the call site, so dispatch through the open-typed
+    // router signature.
+    const parent = this.parent as unknown as WebhookRouter;
+
     for (const event of events) {
       // Reject empty string event types
       if (typeof event === 'string' && event.trim() === '') {
         throw new Error('Event type cannot be an empty string or whitespace');
       }
       const fullEventType = `${this.prefix}.${event}`;
-      this.parent.on(fullEventType, handler);
+      parent.on(fullEventType, handler as EventHandler<WebhookEvent>);
     }
     return this;
   }
@@ -325,7 +359,7 @@ class PrefixedRouter {
   use(middleware: Middleware): this {
     // For simplicity, middleware in groups is applied to the parent router
     // A more advanced implementation could scope middleware to the group
-    this.parent.use(middleware);
+    (this.parent as unknown as WebhookRouter).use(middleware);
     return this;
   }
 }

--- a/packages/core/test/group-types.test-d.ts
+++ b/packages/core/test/group-types.test-d.ts
@@ -1,0 +1,75 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import { WebhookRouter, type WebhookEvent, type EventHandler } from '../src/index.js';
+
+/**
+ * Type-level regression tests for `group()` / `PrefixedRouter`.
+ *
+ * Previously `group()` always exposed handlers as `EventHandler<WebhookEvent>`
+ * (i.e. `data.object: unknown`), losing the event-map type information. These
+ * tests lock in that the prefix + suffix is resolved back to the concrete
+ * event type from the router's event map.
+ */
+
+interface FooCreatedEvent extends WebhookEvent {
+  type: 'foo.created';
+  data: { object: { fooId: string } };
+}
+
+interface FooUpdatedEvent extends WebhookEvent {
+  type: 'foo.updated';
+  data: { object: { fooId: string }; previous: Record<string, unknown> };
+}
+
+interface BarEvent extends WebhookEvent {
+  type: 'bar.happened';
+  data: { object: { barId: number } };
+}
+
+type TestEventMap = {
+  'foo.created': FooCreatedEvent;
+  'foo.updated': FooUpdatedEvent;
+  'bar.happened': BarEvent;
+};
+
+describe('group() type inference', () => {
+  it('resolves a single suffix to the concrete event type', () => {
+    const router = new WebhookRouter<TestEventMap>();
+    router.group('foo', (g) => {
+      g.on('created', async (event) => {
+        expectTypeOf(event).toEqualTypeOf<FooCreatedEvent>();
+        expectTypeOf(event.data.object).toEqualTypeOf<{ fooId: string }>();
+      });
+    });
+  });
+
+  it('resolves an array of suffixes to the union of concrete event types', () => {
+    const router = new WebhookRouter<TestEventMap>();
+    router.group('foo', (g) => {
+      g.on(['created', 'updated'], async (event) => {
+        expectTypeOf(event).toEqualTypeOf<FooCreatedEvent | FooUpdatedEvent>();
+      });
+    });
+  });
+
+  it('rejects suffixes that do not exist for the prefix', () => {
+    const router = new WebhookRouter<TestEventMap>();
+    router.group('foo', (g) => {
+      // @ts-expect-error 'happened' belongs to the 'bar' prefix, not 'foo'
+      g.on('happened', async () => {});
+      // @ts-expect-error 'missing' is not a valid suffix at all
+      g.on('missing', async () => {});
+    });
+  });
+
+  it('falls back to the open string behaviour for the default event map', () => {
+    const router = new WebhookRouter();
+    router.group('anything', (g) => {
+      g.on('whatever', async (event) => {
+        expectTypeOf(event).toEqualTypeOf<WebhookEvent>();
+      });
+      // Arbitrary handler shapes remain assignable for the open map.
+      const handler: EventHandler<WebhookEvent> = async () => {};
+      g.on('also-fine', handler);
+    });
+  });
+});

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -4,6 +4,10 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    typecheck: {
+      enabled: true,
+      include: ['**/*.test-d.ts'],
+    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/packages/create-kotodayori/templates/express/src/index.ts
+++ b/packages/create-kotodayori/templates/express/src/index.ts
@@ -3,7 +3,6 @@ import Stripe from 'stripe';
 import {
   StripeWebhookRouter,
   createStripeVerifier,
-  type StripeEventMap,
 } from '@kotodayori/stripe';
 import { expressAdapter } from '@kotodayori/express';
 import { paymentHandlers } from './handlers/payment.js';
@@ -55,7 +54,7 @@ app.get('/', (_req, res) => {
 app.post(
   '/webhook',
   express.raw({ type: 'application/json' }),
-  expressAdapter<StripeEventMap>(webhookRouter, {
+  expressAdapter(webhookRouter, {
     verifier: createStripeVerifier(stripe, process.env.STRIPE_WEBHOOK_SECRET),
     onError: async (error, event) => {
       console.error(`Failed to process ${event?.type}:`, error);

--- a/packages/create-kotodayori/templates/hono/src/index.ts
+++ b/packages/create-kotodayori/templates/hono/src/index.ts
@@ -3,7 +3,6 @@ import Stripe from 'stripe';
 import {
   StripeWebhookRouter,
   createStripeVerifier,
-  type StripeEventMap,
 } from '@kotodayori/stripe';
 import { honoAdapter } from '@kotodayori/hono';
 import { paymentHandlers } from './handlers/payment.js';
@@ -52,7 +51,7 @@ app.get('/', (c) => {
 
 app.post(
   '/webhook',
-  honoAdapter<StripeEventMap>(webhookRouter, {
+  honoAdapter(webhookRouter, {
     verifier: createStripeVerifier(stripe, process.env.STRIPE_WEBHOOK_SECRET),
     onError: async (error, event) => {
       console.error(`Failed to process ${event?.type}:`, error);

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -38,9 +38,12 @@ export interface ExpressAdapterOptions<T extends WebhookEvent = WebhookEvent> {
  * @param options - Adapter options including a verifier function
  * @returns Express middleware function
  */
-export function expressAdapter<TEventMap extends Record<string, WebhookEvent>>(
+export function expressAdapter<
+  TEventMap extends Record<string, WebhookEvent>,
+  TEvent extends WebhookEvent = TEventMap[keyof TEventMap],
+>(
   router: WebhookRouter<TEventMap>,
-  options: ExpressAdapterOptions<TEventMap[keyof TEventMap]>
+  options: ExpressAdapterOptions<TEvent>
 ): (req: Request, res: Response, next: NextFunction) => Promise<void> {
   const { verifier, onError } = options;
 
@@ -77,12 +80,12 @@ export function expressAdapter<TEventMap extends Record<string, WebhookEvent>>(
       headers[key.toLowerCase()] = Array.isArray(value) ? value[0] : value;
     }
 
-    let event: TEventMap[keyof TEventMap];
+    let event: TEvent;
 
     // Verify signature and parse event
     try {
       const result = await verifier(rawBody, headers);
-      event = result.event as TEventMap[keyof TEventMap];
+      event = result.event;
     } catch (err) {
       console.error('Webhook verification failed:', err);
       res.status(400).json({ error: 'Verification failed' });

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -35,9 +35,12 @@ export interface HonoAdapterOptions<T extends WebhookEvent = WebhookEvent> {
  * @param options - Adapter options including a verifier function
  * @returns Hono handler function
  */
-export function honoAdapter<TEventMap extends Record<string, WebhookEvent>>(
+export function honoAdapter<
+  TEventMap extends Record<string, WebhookEvent>,
+  TEvent extends WebhookEvent = TEventMap[keyof TEventMap],
+>(
   router: WebhookRouter<TEventMap>,
-  options: HonoAdapterOptions<TEventMap[keyof TEventMap]>
+  options: HonoAdapterOptions<TEvent>
 ): (c: Context) => Promise<Response> {
   const { verifier, onError } = options;
 
@@ -55,12 +58,12 @@ export function honoAdapter<TEventMap extends Record<string, WebhookEvent>>(
       headers[key.toLowerCase()] = value;
     });
 
-    let webhookEvent: TEventMap[keyof TEventMap];
+    let webhookEvent: TEvent;
 
     // Verify signature and parse event
     try {
       const result = await verifier(rawBody, headers);
-      webhookEvent = result.event as TEventMap[keyof TEventMap];
+      webhookEvent = result.event;
     } catch (err) {
       console.error('Webhook verification failed:', err);
       return c.json({ error: 'Verification failed' }, 400);

--- a/packages/hono/test/hono-adapter-types.test-d.ts
+++ b/packages/hono/test/hono-adapter-types.test-d.ts
@@ -1,0 +1,68 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import { honoAdapter } from '../src/index.js';
+import { WebhookRouter, type Verifier, type WebhookEvent } from '@kotodayori/core';
+
+/**
+ * Type-level regression tests for `honoAdapter` generic inference.
+ *
+ * Previously the verifier event type was coupled to the router's event map
+ * (`HonoAdapterOptions<TEventMap[keyof TEventMap]>`). When a verifier returned
+ * a union that differed from the map (e.g. a Stripe SDK that ships events the
+ * hand-maintained `StripeEventMap` doesn't have yet), inference fell back to
+ * `Record<string, WebhookEvent>` and the typed router was rejected.
+ *
+ * The verifier event type is now an independently-inferred generic, so router
+ * typing is preserved regardless of the verifier's exact event union.
+ */
+
+interface CreatedEvent extends WebhookEvent {
+  type: 'thing.created';
+  data: { object: { id: string } };
+}
+
+interface UpdatedEvent extends WebhookEvent {
+  type: 'thing.updated';
+  data: { object: { id: string } };
+}
+
+type EventMap = {
+  'thing.created': CreatedEvent;
+  'thing.updated': UpdatedEvent;
+};
+
+// A verifier whose event union is WIDER than the router's map (simulates SDK drift).
+interface DriftEvent extends WebhookEvent {
+  type: 'thing.brand_new';
+  data: { object: unknown };
+}
+
+describe('honoAdapter generic inference', () => {
+  it('accepts a typed router with a verifier whose event union matches the map', () => {
+    const router = new WebhookRouter<EventMap>();
+    const verifier: Verifier<CreatedEvent | UpdatedEvent> = () => ({
+      event: { id: 'e', type: 'thing.created', data: { object: { id: 'x' } } },
+    });
+
+    const handler = honoAdapter(router, { verifier });
+    expectTypeOf(handler).toBeFunction();
+  });
+
+  it('preserves typed-router inference when the verifier union is wider (SDK drift)', () => {
+    const router = new WebhookRouter<EventMap>();
+    const verifier: Verifier<CreatedEvent | UpdatedEvent | DriftEvent> = () => ({
+      event: { id: 'e', type: 'thing.brand_new', data: { object: null } },
+    });
+
+    // Must compile without falling back / requiring a cast on the router.
+    const handler = honoAdapter(router, {
+      verifier,
+      onError: (_error, event) => {
+        // onError receives the verifier's event type, not `unknown`.
+        expectTypeOf(event).toEqualTypeOf<
+          CreatedEvent | UpdatedEvent | DriftEvent | undefined
+        >();
+      },
+    });
+    expectTypeOf(handler).toBeFunction();
+  });
+});

--- a/packages/hono/vitest.config.ts
+++ b/packages/hono/vitest.config.ts
@@ -4,6 +4,10 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    typecheck: {
+      enabled: true,
+      include: ['**/*.test-d.ts'],
+    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/packages/lambda/src/index.ts
+++ b/packages/lambda/src/index.ts
@@ -34,9 +34,12 @@ export interface LambdaAdapterOptions<T extends WebhookEvent = WebhookEvent> {
  * @param options - Adapter options including a verifier function
  * @returns Lambda handler function
  */
-export function lambdaAdapter<TEventMap extends Record<string, WebhookEvent>>(
+export function lambdaAdapter<
+  TEventMap extends Record<string, WebhookEvent>,
+  TEvent extends WebhookEvent = TEventMap[keyof TEventMap],
+>(
   router: WebhookRouter<TEventMap>,
-  options: LambdaAdapterOptions<TEventMap[keyof TEventMap]>
+  options: LambdaAdapterOptions<TEvent>
 ): (event: APIGatewayProxyEvent, context: Context) => Promise<APIGatewayProxyResult> {
   const { verifier, onError } = options;
 
@@ -75,12 +78,12 @@ export function lambdaAdapter<TEventMap extends Record<string, WebhookEvent>>(
       }
     }
 
-    let webhookEvent: TEventMap[keyof TEventMap];
+    let webhookEvent: TEvent;
 
     // Verify signature and parse event
     try {
       const result = await verifier(rawBody, headers);
-      webhookEvent = result.event as TEventMap[keyof TEventMap];
+      webhookEvent = result.event;
     } catch (err) {
       console.error('Webhook verification failed:', err);
       return {


### PR DESCRIPTION
## Summary

This PR significantly improves TypeScript type inference and safety across the webhook router and framework adapters. It enables compile-time validation of event types in grouped routers and decouples verifier event types from router event maps in adapters.

## Key Changes

### Core Router (`@kotodayori/core`)
- **Added `EventSuffix<TEventMap, TPrefix>` type utility** that extracts valid event suffixes for a given prefix from an event map, enabling type-safe suffix validation
- **Enhanced `PrefixedRouter` class with full generic typing** (`PrefixedRouter<TEventMap, TPrefix>`) to preserve parent router's event-map information
- **Improved `WebhookRouter.group()` method** to accept a generic `TPrefix` parameter and pass typed `PrefixedRouter` to the callback
- **Type-safe handler registration in groups**: `group(prefix).on(suffix, handler)` now resolves to the concrete event type for `prefix.suffix` instead of erasing to `WebhookEvent`
- **Compile-time validation**: Invalid suffixes for a given prefix are now rejected by TypeScript
- **Added comprehensive type-level regression tests** (`group-types.test-d.ts`) covering single/multiple suffixes, invalid suffixes, and default event map behavior
- **Enabled Vitest typecheck** for `.test-d.ts` files in core package

### Framework Adapters
- **Decoupled verifier event type from router event map** across all adapters (`honoAdapter`, `expressAdapter`, `lambdaAdapter`)
- **Added independent `TEvent` generic parameter** to adapter functions, defaulting to `TEventMap[keyof TEventMap]` but allowing independent inference
- **Removed unnecessary type casts** (`as TEventMap[keyof TEventMap]`) in adapter implementations
- **Preserved typed router inference** when verifier returns a wider event union (e.g., SDK drift scenarios)
- **Added type-level regression tests** (`hono-adapter-types.test-d.ts`) validating adapter behavior with matching and wider verifier unions
- **Enabled Vitest typecheck** for `.test-d.ts` files in hono package

### Examples & Templates
- **Simplified adapter usage** by removing explicit `<StripeEventMap>` type parameters from `expressAdapter()` and `honoAdapter()` calls in examples and templates
- Type inference now works automatically without manual type specification

## Implementation Details

The `EventSuffix` type utility uses conditional type inference to extract suffixes from event map keys:
```typescript
Extract<keyof TEventMap, `${TPrefix}.${string}`> extends `${TPrefix}.${infer TSuffix}`
  ? TSuffix
  : never
```

This enables the `PrefixedRouter.on()` overloads to accept only valid suffixes and resolve to the correct event type from the parent router's map.

The adapter improvements use a two-generic pattern where `TEvent` is independently inferred from the verifier's return type, allowing it to differ from the router's event map while still preserving the router's type safety.

https://claude.ai/code/session_01EfvjTeZhdUbmqrkUN2LJFz