### PR TITLE
feat(create-kotodayori): offer agent skill install during create

### DIFF
--- a/.changeset/kotodayori-agent-skill-create.md
+++ b/.changeset/kotodayori-agent-skill-create.md
@@ -1,0 +1,10 @@
+---
+"create-kotodayori": minor
+---
+
+Add optional `kotodayori-webhooks` agent skill installation to the scaffolder.
+When run interactively, `create-kotodayori` now asks whether to drop the agent
+skill (`SKILL.md`) into the new project for Claude Code (`.claude/skills`) and/or
+Cursor (`.cursor/skills`). A `--skill <agents>` flag (`claude-code`, `cursor`,
+`all`, `none`, comma-separated) and `--no-skill` are available for non-interactive
+use.

--- a/packages/create-kotodayori/README.md
+++ b/packages/create-kotodayori/README.md
@@ -36,6 +36,20 @@ Skip dependency installation:
 npx create-kotodayori --fw=hono --skip-install
 ```
 
+Add the `kotodayori-webhooks` agent skill for AI coding agents:
+
+```bash
+# One agent
+npx create-kotodayori --fw=hono --skill=claude-code
+
+# Multiple agents (comma-separated) or "all"
+npx create-kotodayori --fw=hono --skill=claude-code,cursor
+npx create-kotodayori --fw=hono --skill=all
+
+# Skip the skill (also skips the prompt)
+npx create-kotodayori --fw=hono --no-skill
+```
+
 ### All Options
 
 ```bash
@@ -45,9 +59,25 @@ Options:
   --fw, --framework <framework>     Framework to use (hono, express, lambda, eventbridge)
   --pm, --package-manager <pm>      Package manager to use (pnpm, npm, yarn, bun)
   --skip-install                    Skip installing dependencies
+  --skill <agents>                  Add the kotodayori-webhooks agent skill
+                                    (claude-code, cursor, all, none; comma-separated)
+  --no-skill                        Skip adding the agent skill
   -h, --help                        Display help message
   -v, --version                     Display version number
 ```
+
+## Agent skill
+
+When run interactively, `create-kotodayori` asks whether to drop the
+[`kotodayori-webhooks`](https://github.com/hideokamoto/kotodayori/tree/main/skills/kotodayori-webhooks)
+agent skill into your new project so AI coding agents (Claude Code, Cursor)
+understand the Kotodayori APIs out of the box. The `SKILL.md` is written to the
+agent's project-local skills directory:
+
+| Agent | Location |
+| --- | --- |
+| Claude Code | `.claude/skills/kotodayori-webhooks/SKILL.md` |
+| Cursor | `.cursor/skills/kotodayori-webhooks/SKILL.md` |
 
 ## Supported Frameworks
 
@@ -76,12 +106,14 @@ $ npx create-kotodayori
 ? Select framework: Hono
 ? Select package manager: pnpm
 ? Install dependencies? Yes
+? Add the kotodayori-webhooks agent skill? Claude Code
 
 Creating Kotodayori + Hono project...
 
 ✔ Template files created
 ✔ Dependencies installed successfully
 ✔ Project created successfully! 🎉
+✔ Added agent skill: .claude/skills/kotodayori-webhooks/SKILL.md
 
 Next steps:
 

--- a/packages/create-kotodayori/package.json
+++ b/packages/create-kotodayori/package.json
@@ -11,6 +11,8 @@
     "templates"
   ],
   "scripts": {
+    "sync:skill": "node scripts/sync-skill.mjs",
+    "prebuild": "node scripts/sync-skill.mjs",
     "build": "tsup",
     "dev": "tsup --watch",
     "test": "vitest run",

--- a/packages/create-kotodayori/scripts/sync-skill.mjs
+++ b/packages/create-kotodayori/scripts/sync-skill.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// Sync the distributable agent skill (skills/kotodayori-webhooks/SKILL.md) into
+// this package's templates so it ships inside the published npm tarball.
+//
+// The repository keeps a single source of truth at skills/kotodayori-webhooks/.
+// create-kotodayori is published standalone, so it needs its own bundled copy.
+// This script copies the source into templates/skill/SKILL.md. It is wired into
+// the package "prebuild" step, and skips silently when the source is missing
+// (e.g. installing from a tarball where the monorepo skills dir is absent).
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(__dirname, '..');
+const repoRoot = path.resolve(packageRoot, '..', '..');
+
+const source = path.join(repoRoot, 'skills', 'kotodayori-webhooks', 'SKILL.md');
+const destDir = path.join(packageRoot, 'templates', 'skill');
+const dest = path.join(destDir, 'SKILL.md');
+
+async function main() {
+  let content;
+  try {
+    content = await fs.readFile(source, 'utf-8');
+  } catch {
+    console.log(`[sync-skill] source not found (${source}); skipping.`);
+    return;
+  }
+
+  await fs.mkdir(destDir, { recursive: true });
+  await fs.writeFile(dest, content);
+  console.log(`[sync-skill] copied SKILL.md -> ${path.relative(packageRoot, dest)}`);
+}
+
+main().catch((error) => {
+  console.error('[sync-skill] failed:', error);
+  process.exit(1);
+});

--- a/packages/create-kotodayori/src/cli.test.ts
+++ b/packages/create-kotodayori/src/cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseCli } from './cli.js';
+import { parseCli, parseSkillOption } from './cli.js';
 
 describe('CLI Parser', () => {
   describe('Project Name', () => {
@@ -72,6 +72,64 @@ describe('CLI Parser', () => {
     it('should default to undefined when flag is not provided', () => {
       const options = parseCli(['node', 'create-kotodayori']);
       expect(options.skipInstall).toBeUndefined();
+    });
+  });
+
+  describe('Agent Skill Option', () => {
+    it('should parse a single agent', () => {
+      const options = parseCli(['node', 'create-kotodayori', '--skill', 'claude-code']);
+      expect(options.agentSkills).toEqual(['claude-code']);
+    });
+
+    it('should parse a comma-separated list of agents', () => {
+      const options = parseCli(['node', 'create-kotodayori', '--skill', 'claude-code,cursor']);
+      expect(options.agentSkills).toEqual(['claude-code', 'cursor']);
+    });
+
+    it('should expand "all" to every supported agent', () => {
+      const options = parseCli(['node', 'create-kotodayori', '--skill', 'all']);
+      expect(options.agentSkills).toEqual(['claude-code', 'cursor']);
+    });
+
+    it('should treat "none" as an explicit empty selection', () => {
+      const options = parseCli(['node', 'create-kotodayori', '--skill', 'none']);
+      expect(options.agentSkills).toEqual([]);
+    });
+
+    it('should treat --no-skill as an explicit empty selection', () => {
+      const options = parseCli(['node', 'create-kotodayori', '--no-skill']);
+      expect(options.agentSkills).toEqual([]);
+    });
+
+    it('should be undefined when no skill flag is provided', () => {
+      const options = parseCli(['node', 'create-kotodayori']);
+      expect(options.agentSkills).toBeUndefined();
+    });
+  });
+
+  describe('parseSkillOption', () => {
+    it('returns undefined when the flag is absent', () => {
+      expect(parseSkillOption(undefined)).toBeUndefined();
+    });
+
+    it('returns [] for --no-skill (false)', () => {
+      expect(parseSkillOption(false)).toEqual([]);
+    });
+
+    it('accepts the "claude" alias', () => {
+      expect(parseSkillOption('claude')).toEqual(['claude-code']);
+    });
+
+    it('deduplicates repeated agents', () => {
+      expect(parseSkillOption('cursor,cursor')).toEqual(['cursor']);
+    });
+
+    it('ignores unknown tokens', () => {
+      expect(parseSkillOption('cursor,bogus')).toEqual(['cursor']);
+    });
+
+    it('is case and whitespace insensitive', () => {
+      expect(parseSkillOption(' Claude-Code , CURSOR ')).toEqual(['claude-code', 'cursor']);
     });
   });
 

--- a/packages/create-kotodayori/src/cli.ts
+++ b/packages/create-kotodayori/src/cli.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import type { PackageManager } from './utils/install.js';
+import type { SkillAgent } from './utils/files.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageJson = JSON.parse(
@@ -16,6 +17,51 @@ export interface CliOptions {
   framework?: Framework;
   packageManager?: PackageManager;
   skipInstall?: boolean;
+  agentSkills?: SkillAgent[];
+}
+
+/**
+ * Parse the `--skill` / `--no-skill` value into a list of agents.
+ * Accepts a comma-separated list, plus the shortcuts `all` and `none`.
+ * Returns undefined when the flag was not provided (so we still prompt).
+ */
+export function parseSkillOption(value: unknown): SkillAgent[] | undefined {
+  // `--no-skill` makes cac set the value to `false`.
+  if (value === false) {
+    return [];
+  }
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const tokens = value
+    .split(',')
+    .map((token) => token.trim().toLowerCase())
+    .filter(Boolean);
+
+  const agents = new Set<SkillAgent>();
+  for (const token of tokens) {
+    switch (token) {
+      case 'none':
+        return [];
+      case 'all':
+        agents.add('claude-code');
+        agents.add('cursor');
+        break;
+      case 'claude':
+      case 'claude-code':
+        agents.add('claude-code');
+        break;
+      case 'cursor':
+        agents.add('cursor');
+        break;
+      default:
+        // Ignore unknown tokens rather than failing the whole run.
+        break;
+    }
+  }
+
+  return Array.from(agents);
 }
 
 export function parseCli(argv?: string[]): CliOptions {
@@ -27,6 +73,10 @@ export function parseCli(argv?: string[]): CliOptions {
     .option('--fw, --framework <framework>', 'Framework to use (hono, express, lambda, eventbridge)')
     .option('--pm, --package-manager <pm>', 'Package manager to use (pnpm, npm, yarn, bun)')
     .option('--skip-install', 'Skip installing dependencies')
+    .option(
+      '--skill <agents>',
+      'Add the kotodayori-webhooks agent skill (claude-code, cursor, all, none; comma-separated). Use --no-skill to skip.'
+    )
     .help();
 
   const parsed = cli.parse(argv);
@@ -51,6 +101,11 @@ export function parseCli(argv?: string[]): CliOptions {
   const skipInstall = parsed.options['skipInstall'];
   if (skipInstall !== undefined) {
     options.skipInstall = skipInstall;
+  }
+
+  const agentSkills = parseSkillOption(parsed.options['skill']);
+  if (agentSkills !== undefined) {
+    options.agentSkills = agentSkills;
   }
 
   return options;

--- a/packages/create-kotodayori/src/index.ts
+++ b/packages/create-kotodayori/src/index.ts
@@ -10,7 +10,7 @@ import { generateExpressProject } from './generators/express.js';
 import { generateLambdaProject } from './generators/lambda.js';
 import { generateEventBridgeProject } from './generators/eventbridge.js';
 import { logger } from './utils/logger.js';
-import { pathExists, isEmpty } from './utils/files.js';
+import { pathExists, isEmpty, copyAgentSkill } from './utils/files.js';
 
 async function main() {
   console.log();
@@ -28,6 +28,7 @@ async function main() {
     if (cliOptions.framework) configInput.framework = cliOptions.framework;
     if (cliOptions.packageManager) configInput.packageManager = cliOptions.packageManager;
     if (cliOptions.skipInstall !== undefined) configInput.shouldInstall = !cliOptions.skipInstall;
+    if (cliOptions.agentSkills !== undefined) configInput.agentSkills = cliOptions.agentSkills;
 
     const config = await promptForConfig(configInput);
 
@@ -87,6 +88,14 @@ async function main() {
           `Framework "${config.framework}" is not supported.`
         );
         process.exit(1);
+    }
+
+    // Optionally add the kotodayori-webhooks agent skill for AI coding agents.
+    if (config.agentSkills.length > 0) {
+      const written = await copyAgentSkill(targetDir, config.agentSkills);
+      for (const file of written) {
+        logger.success(`Added agent skill: ${file}`);
+      }
     }
   } catch (error) {
     console.log();

--- a/packages/create-kotodayori/src/prompts.test.ts
+++ b/packages/create-kotodayori/src/prompts.test.ts
@@ -22,6 +22,7 @@ describe('Prompts', () => {
         framework: 'hono',
         packageManager: 'pnpm',
         shouldInstall: true,
+        agentSkills: [],
       });
 
       expect(config).toEqual({
@@ -29,6 +30,7 @@ describe('Prompts', () => {
         framework: 'hono',
         packageManager: 'pnpm',
         shouldInstall: true,
+        agentSkills: [],
       });
 
       // Should not prompt for anything since all values are provided
@@ -126,6 +128,7 @@ describe('Prompts', () => {
         framework: 'lambda',
         packageManager: 'bun',
         shouldInstall: true,
+        agentSkills: ['claude-code'],
       });
 
       const config = await promptForConfig({});
@@ -135,12 +138,69 @@ describe('Prompts', () => {
         framework: 'lambda',
         packageManager: 'bun',
         shouldInstall: true,
+        agentSkills: ['claude-code'],
       });
 
       const calls = vi.mocked(prompts).mock.calls[0];
       expect(calls).toBeDefined();
       const questions = calls?.[0] as prompts.PromptObject[];
-      expect(questions.length).toBe(4);
+      expect(questions.length).toBe(5);
+    });
+
+    it('should prompt for missing agentSkills', async () => {
+      const prompts = (await import('prompts')).default;
+      vi.mocked(prompts).mockResolvedValue({
+        agentSkills: ['claude-code', 'cursor'],
+      });
+
+      const config = await promptForConfig({
+        projectName: 'my-project',
+        framework: 'hono',
+        packageManager: 'pnpm',
+        shouldInstall: true,
+      });
+
+      expect(config.agentSkills).toEqual(['claude-code', 'cursor']);
+
+      const calls = vi.mocked(prompts).mock.calls[0];
+      expect(calls).toBeDefined();
+      const questions = calls?.[0] as prompts.PromptObject[];
+      expect(questions.some((q: prompts.PromptObject) => q.name === 'agentSkills')).toBe(true);
+    });
+
+    it('should not prompt for agentSkills when provided (including empty)', async () => {
+      const prompts = (await import('prompts')).default;
+      vi.mocked(prompts).mockResolvedValue({});
+
+      const config = await promptForConfig({
+        projectName: 'my-project',
+        framework: 'hono',
+        packageManager: 'pnpm',
+        shouldInstall: true,
+        agentSkills: [],
+      });
+
+      expect(config.agentSkills).toEqual([]);
+
+      const calls = vi.mocked(prompts).mock.calls[0];
+      expect(calls).toBeDefined();
+      const questions = calls?.[0] as prompts.PromptObject[];
+      expect(questions.some((q: prompts.PromptObject) => q.name === 'agentSkills')).toBe(false);
+    });
+
+    it('should default agentSkills to empty array when none selected', async () => {
+      const prompts = (await import('prompts')).default;
+      // multiselect returns undefined / nothing when the user selects nothing
+      vi.mocked(prompts).mockResolvedValue({});
+
+      const config = await promptForConfig({
+        projectName: 'my-project',
+        framework: 'hono',
+        packageManager: 'pnpm',
+        shouldInstall: true,
+      });
+
+      expect(config.agentSkills).toEqual([]);
     });
 
     it('should handle shouldInstall=false correctly', async () => {

--- a/packages/create-kotodayori/src/prompts.ts
+++ b/packages/create-kotodayori/src/prompts.ts
@@ -1,12 +1,14 @@
 import prompts from 'prompts';
 import type { Framework } from './cli.js';
 import type { PackageManager } from './utils/install.js';
+import type { SkillAgent } from './utils/files.js';
 
 export interface ProjectConfig {
   projectName: string;
   framework: Framework;
   packageManager: PackageManager;
   shouldInstall: boolean;
+  agentSkills: SkillAgent[];
 }
 
 export async function promptForConfig(
@@ -64,6 +66,20 @@ export async function promptForConfig(
     });
   }
 
+  if (initialConfig.agentSkills === undefined) {
+    questions.push({
+      type: 'multiselect',
+      name: 'agentSkills',
+      message: 'Add the kotodayori-webhooks agent skill?',
+      choices: [
+        { title: 'Claude Code (.claude/skills)', value: 'claude-code' },
+        { title: 'Cursor (.cursor/skills)', value: 'cursor' },
+      ],
+      hint: '- Space to select, Enter to confirm. Leave empty to skip.',
+      instructions: false,
+    });
+  }
+
   const answers = await prompts(questions, {
     onCancel: () => {
       console.log('\nCancelled.');
@@ -79,5 +95,9 @@ export async function promptForConfig(
       initialConfig.shouldInstall !== undefined
         ? initialConfig.shouldInstall
         : answers['shouldInstall'],
+    agentSkills:
+      initialConfig.agentSkills !== undefined
+        ? initialConfig.agentSkills
+        : (answers['agentSkills'] ?? []),
   };
 }

--- a/packages/create-kotodayori/src/utils/files.test.ts
+++ b/packages/create-kotodayori/src/utils/files.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { pathExists, isEmpty, writeJson, copyDir, copyAgentSkill } from './files.js';
@@ -159,6 +159,20 @@ describe('File Utilities', () => {
         path.join('.claude', 'skills', 'kotodayori-webhooks', 'SKILL.md'),
         path.join('.cursor', 'skills', 'kotodayori-webhooks', 'SKILL.md'),
       ]);
+    });
+
+    it('should throw a path-specific error when the skill template is missing', async () => {
+      const spy = vi
+        .spyOn(fs, 'readFile')
+        .mockRejectedValueOnce(
+          Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' })
+        );
+
+      await expect(copyAgentSkill(testDir, ['claude-code'])).rejects.toThrow(
+        /Agent skill template not found at .*SKILL\.md/
+      );
+
+      spy.mockRestore();
     });
   });
 

--- a/packages/create-kotodayori/src/utils/files.test.ts
+++ b/packages/create-kotodayori/src/utils/files.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { pathExists, isEmpty, writeJson, copyDir } from './files.js';
+import { pathExists, isEmpty, writeJson, copyDir, copyAgentSkill } from './files.js';
 
 describe('File Utilities', () => {
   const testDir = path.join(process.cwd(), 'test-temp');
@@ -120,6 +120,45 @@ describe('File Utilities', () => {
 
       const content = await fs.readFile(path.join(destDir, 'package.json'), 'utf-8');
       expect(content).toBe('{"name":"my-app"}');
+    });
+  });
+
+  describe('copyAgentSkill', () => {
+    it('should return an empty list and write nothing when no agents are given', async () => {
+      const written = await copyAgentSkill(testDir, []);
+      expect(written).toEqual([]);
+
+      const entries = await fs.readdir(testDir);
+      expect(entries).toEqual([]);
+    });
+
+    it('should write SKILL.md into the Claude Code skills directory', async () => {
+      const written = await copyAgentSkill(testDir, ['claude-code']);
+
+      const expectedPath = path.join('.claude', 'skills', 'kotodayori-webhooks', 'SKILL.md');
+      expect(written).toEqual([expectedPath]);
+
+      const content = await fs.readFile(path.join(testDir, expectedPath), 'utf-8');
+      expect(content).toContain('name: kotodayori-webhooks');
+    });
+
+    it('should write SKILL.md into the Cursor skills directory', async () => {
+      const written = await copyAgentSkill(testDir, ['cursor']);
+
+      const expectedPath = path.join('.cursor', 'skills', 'kotodayori-webhooks', 'SKILL.md');
+      expect(written).toEqual([expectedPath]);
+
+      const exists = await pathExists(path.join(testDir, expectedPath));
+      expect(exists).toBe(true);
+    });
+
+    it('should write to multiple agent directories at once', async () => {
+      const written = await copyAgentSkill(testDir, ['claude-code', 'cursor']);
+
+      expect(written).toEqual([
+        path.join('.claude', 'skills', 'kotodayori-webhooks', 'SKILL.md'),
+        path.join('.cursor', 'skills', 'kotodayori-webhooks', 'SKILL.md'),
+      ]);
     });
   });
 

--- a/packages/create-kotodayori/src/utils/files.ts
+++ b/packages/create-kotodayori/src/utils/files.ts
@@ -66,6 +66,45 @@ export async function copyDir(
   }
 }
 
+export type SkillAgent = 'claude-code' | 'cursor';
+
+const SKILL_NAME = 'kotodayori-webhooks';
+
+// Where each agent expects project-local skills to live.
+const AGENT_SKILL_DIRS: Record<SkillAgent, string> = {
+  'claude-code': '.claude/skills',
+  cursor: '.cursor/skills',
+};
+
+/**
+ * Copy the bundled kotodayori-webhooks agent skill into the generated project
+ * for each requested agent. Returns the list of written paths (relative to
+ * targetDir) so the caller can report them.
+ */
+export async function copyAgentSkill(
+  targetDir: string,
+  agents: SkillAgent[]
+): Promise<string[]> {
+  if (agents.length === 0) {
+    return [];
+  }
+
+  const packageRoot = getPackageRoot();
+  const skillSource = path.join(packageRoot, 'templates', 'skill', 'SKILL.md');
+  const content = await fs.readFile(skillSource, 'utf-8');
+
+  const written: string[] = [];
+  for (const agent of agents) {
+    const destDir = path.join(targetDir, AGENT_SKILL_DIRS[agent], SKILL_NAME);
+    await fs.mkdir(destDir, { recursive: true });
+    const destPath = path.join(destDir, 'SKILL.md');
+    await fs.writeFile(destPath, content);
+    written.push(path.relative(targetDir, destPath));
+  }
+
+  return written;
+}
+
 export async function writeJson(
   filePath: string,
   data: Record<string, unknown>

--- a/packages/create-kotodayori/src/utils/files.ts
+++ b/packages/create-kotodayori/src/utils/files.ts
@@ -91,7 +91,16 @@ export async function copyAgentSkill(
 
   const packageRoot = getPackageRoot();
   const skillSource = path.join(packageRoot, 'templates', 'skill', 'SKILL.md');
-  const content = await fs.readFile(skillSource, 'utf-8');
+  let content: string;
+  try {
+    content = await fs.readFile(skillSource, 'utf-8');
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Agent skill template not found at ${skillSource}. ` +
+        `Run "node scripts/sync-skill.mjs" (or rebuild) to regenerate it. (${reason})`
+    );
+  }
 
   const written: string[] = [];
   for (const agent of agents) {

--- a/packages/create-kotodayori/templates/skill/SKILL.md
+++ b/packages/create-kotodayori/templates/skill/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: kotodayori-webhooks
+description: >
+  Kotodayori: type-safe webhook routing (@kotodayori/core), Stripe helpers
+  (@kotodayori/stripe), adapters (hono, express, lambda, eventbridge), Zod
+  (@kotodayori/zod), and create-kotodayori scaffolding. Use when implementing
+  or debugging webhook routes, signature verification, Stripe event handlers,
+  framework adapters, or the create-kotodayori CLI. Keywords: WebhookRouter,
+  StripeWebhookRouter, createStripeVerifier, honoAdapter, expressAdapter,
+  express.raw, create-kotodayori, kotodayori.
+user-invocable: true
+metadata:
+  author: kotodayori
+  version: "1.0.0"
+---
+
+# Kotodayori webhooks (agent playbook)
+
+Use this skill when working on webhook routing, Stripe verification, adapters, the scaffold CLI, or sample apps that use Kotodayori.
+
+## Installation (from this repository)
+
+This skill is published as a **directory under `skills/kotodayori-webhooks/`** in the [kotodayori](https://github.com/hideokamoto/kotodayori) repo, compatible with the [`skills` CLI](https://www.npmjs.com/package/skills) used by [vercel-labs/agent-skills](https://github.com/vercel-labs/agent-skills).
+
+### Option A: `npx skills add` (recommended)
+
+```bash
+# Default branch on GitHub — install only this skill into the current project
+npx skills add hideokamoto/kotodayori --skill kotodayori-webhooks -y
+
+# Or point at the skill subtree (branch name may differ before merge)
+npx skills add https://github.com/hideokamoto/kotodayori/tree/main/skills/kotodayori-webhooks -y
+```
+
+Use `-g` to install into the user home agent directories instead of the project. Combine with `-a cursor` / `-a claude-code` (see `npx skills add --help`) to target a specific agent.
+
+### Option B: `gh` clone + `npx skills add`
+
+```bash
+gh repo clone hideokamoto/kotodayori /tmp/kotodayori -- --depth 1
+npx skills add /tmp/kotodayori/skills/kotodayori-webhooks --copy -y
+rm -rf /tmp/kotodayori
+```
+
+### Option C: sparse checkout (minimal download)
+
+```bash
+mkdir kotodayori-skill && cd kotodayori-skill
+git init
+git remote add origin https://github.com/hideokamoto/kotodayori.git
+git sparse-checkout init --cone
+git sparse-checkout set skills/kotodayori-webhooks
+git pull origin main
+cd ..
+npx skills add ./kotodayori-skill/skills/kotodayori-webhooks -y
+```
+
+More detail: [`skills/README.md`](https://github.com/hideokamoto/kotodayori/blob/main/skills/README.md) in the same repository.
+
+## Mental model
+
+1. **Core** (`@kotodayori/core`): `WebhookRouter` dispatches typed events; middleware and grouping behave like a small Hono-style stack.
+2. **Verification**: A `Verifier` receives the **raw** payload and headers, verifies authenticity, then returns `{ event }` as `WebhookEvent`. Adapters must not parse JSON before the verifier runs.
+3. **Adapters** bridge HTTP or AWS event shapes to `router.dispatch(event)` and map errors to 400 (bad signature) / 500 (handler) as documented in each package.
+
+## Repository layout (when hacking on Kotodayori itself)
+
+If the workspace is the **kotodayori monorepo**:
+
+- `packages/core` — router engine and shared types
+- `packages/stripe` — `StripeWebhookRouter`, `createStripeVerifier`, `StripeEventMap`
+- `packages/hono`, `packages/express`, `packages/lambda`, `packages/eventbridge` — adapters
+- `packages/zod` — runtime validation helpers (peer: `zod` v4+)
+- `packages/create-kotodayori` — `npx create-kotodayori` templates and CLI
+- `examples/sample-hono-stripe`, `examples/sample-express-stripe` — samples using `workspace:*`
+
+## Critical rules
+
+### Raw body (Stripe and most HMAC providers)
+
+- **Hono**: use `honoAdapter`; it reads raw text from the request for verification.
+- **Express**: apply `express.raw({ type: 'application/json' })` **only** on the webhook path **before** `expressAdapter`. If the body was parsed by `express.json()`, signature verification will fail.
+
+### TypeScript + adapters
+
+- Pass the event map generic on adapters when using Stripe: `honoAdapter<StripeEventMap>(router, { ... })` and `expressAdapter<StripeEventMap>(router, { ... })` so inference lines up with `createStripeVerifier`.
+- Prefer full Stripe event names in `router.on('customer.subscription.created', ...)` over `router.group(...)` when you need precise `event.data.object` typing (`group()` registers handlers as generic `WebhookEvent` today).
+
+### Errors
+
+- Do not leak stack traces or secrets in HTTP responses. Follow existing adapter patterns (`onError` callback, generic 500 body).
+
+## Scaffolding (`create-kotodayori`)
+
+Non-interactive usage:
+
+```bash
+npx create-kotodayori my-app --fw=hono --pm=pnpm --skip-install
+```
+
+Frameworks: `hono`, `express`, `lambda`, `eventbridge`.
+
+Inside the **kotodayori** monorepo you can also run the workspace CLI after `pnpm --filter create-kotodayori build`, then point `node packages/create-kotodayori/dist/index.js ...` at a target directory. After generating samples there, set `@kotodayori/*` to `workspace:*` and `"private": true` when appropriate.
+
+## Typical edit flow (monorepo)
+
+1. Change implementation under `packages/<pkg>/src/`.
+2. Adjust or add tests in `packages/<pkg>/test/`.
+3. From repo root: `pnpm build && pnpm typecheck && pnpm lint && pnpm test`.
+4. If templates change, rebuild the CLI and regenerate or manually sync `examples/` and `packages/create-kotodayori/templates/`.
+
+## Stripe event map maintenance
+
+When the Stripe SDK peer range moves, use `packages/stripe` scripts and `MAINTAINING_STRIPE_EVENTMAP.md`. Prefer running `pnpm run check-events` inside `packages/stripe` after dependency updates.
+
+## Verification commands (monorepo)
+
+```bash
+pnpm build
+pnpm typecheck
+pnpm lint
+pnpm test
+```
+
+For example packages after a full workspace build:
+
+```bash
+pnpm --filter sample-hono-stripe typecheck
+pnpm --filter sample-express-stripe typecheck
+```
+
+## Related docs
+
+- Upstream repository: [github.com/hideokamoto/kotodayori](https://github.com/hideokamoto/kotodayori)
+- Maintainer-oriented guide in that repo: `claude.md`
+- User overview: `README.md`


### PR DESCRIPTION
When scaffolding a project, ask whether to add the kotodayori-webhooks
agent skill and write SKILL.md into the chosen agent directories
(.claude/skills, .cursor/skills). Adds --skill/--no-skill flags for
non-interactive use, bundles the skill via a prebuild sync step, and
documents the new behavior.