### PR TITLE
fix: accept structural WebhookDispatcher in adapters to remove router casts

### DIFF
--- a/.changeset/fix-adapter-nominal-router.md
+++ b/.changeset/fix-adapter-nominal-router.md
@@ -1,0 +1,34 @@
+---
+"@kotodayori/core": minor
+"@kotodayori/hono": patch
+"@kotodayori/express": patch
+"@kotodayori/lambda": patch
+"@kotodayori/eventbridge": patch
+"@kotodayori/stripe": patch
+---
+
+Add `WebhookDispatcher` structural interface; adapters no longer require `as unknown as WebhookRouter` casts.
+
+The root cause of consumers needing `honoAdapter(router as unknown as WebhookRouter, ...)` was that
+`WebhookRouter` is a **nominal** type (its `private handlers` and `private middlewares` fields make
+TypeScript treat two instances of the class from different installed copies of `@kotodayori/core` as
+incompatible). When a consumer's project ends up with duplicate installs — e.g. `@kotodayori/hono`
+and `@kotodayori/stripe` resolving to different `@kotodayori/core` versions — the `StripeWebhookRouter`
+the user holds is not assignable to the `WebhookRouter` the adapter expects.
+
+**Changes:**
+
+- `@kotodayori/core` exports a new `WebhookDispatcher<TEvent>` interface with a single method:
+  `dispatch(event: TEvent): Promise<void>`. Interfaces are matched **structurally**, so a router from
+  any copy of core satisfies it. `WebhookRouter` now declares `implements WebhookDispatcher`.
+
+- All adapters (`honoAdapter`, `expressAdapter`, `lambdaAdapter`, `eventBridgeAdapter`) now accept
+  `WebhookDispatcher` for their `router` parameter instead of the concrete `WebhookRouter` class.
+  Verifier-event type inference (`TEvent`) is preserved independently of the router parameter.
+
+- All adapter packages re-export `WebhookDispatcher` from their public surface alongside the existing
+  core re-exports. `@kotodayori/stripe` also re-exports it for convenience.
+
+- Internal `workspace:*` dependency ranges on `@kotodayori/core` are changed to `workspace:^` so that
+  published packages use a caret range (e.g. `^1.1.0`), allowing package managers to deduplicate to a
+  single copy and preventing the duplicate-install scenario in the first place.

--- a/.changeset/fix-adapter-nominal-router.md
+++ b/.changeset/fix-adapter-nominal-router.md
@@ -5,6 +5,7 @@
 "@kotodayori/lambda": patch
 "@kotodayori/eventbridge": patch
 "@kotodayori/stripe": patch
+"@kotodayori/zod": patch
 ---
 
 Add `WebhookDispatcher` structural interface; adapters no longer require `as unknown as WebhookRouter` casts.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -100,13 +100,25 @@ export interface FanoutOptions {
 }
 
 /**
+ * Structural contract an adapter needs from a router: just the ability to
+ * dispatch a verified event. Adapters accept this interface instead of the
+ * concrete `WebhookRouter` class so that a router from a *different installed
+ * copy* of `@kotodayori/core` (duplicate install) is still accepted without a
+ * cast — interfaces are matched structurally, whereas `WebhookRouter` is
+ * nominal because of its private fields.
+ */
+export interface WebhookDispatcher<TEvent extends WebhookEvent = WebhookEvent> {
+  dispatch(event: TEvent): Promise<void>;
+}
+
+/**
  * WebhookRouter - A type-safe event router for webhook events
  *
  * @typeParam TEventMap - A mapping of event type strings to their event types
  */
 export class WebhookRouter<
   TEventMap extends Record<string, WebhookEvent> = DefaultEventMap,
-> {
+> implements WebhookDispatcher<TEventMap[keyof TEventMap] | WebhookEvent> {
   private handlers: Map<string, EventHandler<WebhookEvent>[]> = new Map();
   private middlewares: Middleware[] = [];
 

--- a/packages/eventbridge/package.json
+++ b/packages/eventbridge/package.json
@@ -27,7 +27,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@kotodayori/core": "workspace:*"
+    "@kotodayori/core": "workspace:^"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.159",

--- a/packages/eventbridge/src/index.ts
+++ b/packages/eventbridge/src/index.ts
@@ -15,7 +15,7 @@ export interface EventBridgeAdapterOptions {
  * Note: EventBridge events don't require signature verification as AWS
  * guarantees the authenticity of events delivered through EventBridge.
  *
- * @param router - The WebhookRouter instance
+ * @param router - A WebhookDispatcher (any object with a `dispatch(event)` method, e.g. WebhookRouter)
  * @param options - Adapter options
  * @returns Lambda handler function
  */

--- a/packages/eventbridge/src/index.ts
+++ b/packages/eventbridge/src/index.ts
@@ -1,5 +1,5 @@
 import type { EventBridgeEvent, Context } from 'aws-lambda';
-import type { WebhookRouter, WebhookEvent } from '@kotodayori/core';
+import type { WebhookDispatcher, WebhookEvent } from '@kotodayori/core';
 
 /**
  * Options for the EventBridge adapter
@@ -19,8 +19,8 @@ export interface EventBridgeAdapterOptions {
  * @param options - Adapter options
  * @returns Lambda handler function
  */
-export function eventBridgeAdapter<TEventMap extends Record<string, WebhookEvent>>(
-  router: WebhookRouter<TEventMap>,
+export function eventBridgeAdapter(
+  router: WebhookDispatcher,
   options: EventBridgeAdapterOptions = {}
 ): (event: EventBridgeEvent<string, unknown>, context: Context) => Promise<void> {
   return async (
@@ -67,4 +67,4 @@ export function eventBridgeAdapter<TEventMap extends Record<string, WebhookEvent
 }
 
 // Re-export core types
-export { WebhookRouter, type WebhookEvent, type EventHandler, type Middleware, type Verifier, type VerifyResult } from '@kotodayori/core';
+export { WebhookRouter, type WebhookDispatcher, type WebhookEvent, type EventHandler, type Middleware, type Verifier, type VerifyResult } from '@kotodayori/core';

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -27,7 +27,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@kotodayori/core": "workspace:*"
+    "@kotodayori/core": "workspace:^"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -41,7 +41,7 @@ export interface ExpressAdapterOptions<T extends WebhookEvent = WebhookEvent> {
 export function expressAdapter<
   TEvent extends WebhookEvent = WebhookEvent,
 >(
-  router: WebhookDispatcher,
+  router: WebhookDispatcher<TEvent>,
   options: ExpressAdapterOptions<TEvent>
 ): (req: Request, res: Response, next: NextFunction) => Promise<void> {
   const { verifier, onError } = options;

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -34,7 +34,7 @@ export interface ExpressAdapterOptions<T extends WebhookEvent = WebhookEvent> {
  * );
  * ```
  *
- * @param router - The WebhookRouter instance
+ * @param router - A WebhookDispatcher (any object with a `dispatch(event)` method, e.g. WebhookRouter)
  * @param options - Adapter options including a verifier function
  * @returns Express middleware function
  */

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, NextFunction } from 'express';
-import type { WebhookRouter, WebhookEvent, Verifier } from '@kotodayori/core';
+import type { WebhookDispatcher, WebhookEvent, Verifier } from '@kotodayori/core';
 
 /**
  * Options for the Express adapter
@@ -39,10 +39,9 @@ export interface ExpressAdapterOptions<T extends WebhookEvent = WebhookEvent> {
  * @returns Express middleware function
  */
 export function expressAdapter<
-  TEventMap extends Record<string, WebhookEvent>,
-  TEvent extends WebhookEvent = TEventMap[keyof TEventMap],
+  TEvent extends WebhookEvent = WebhookEvent,
 >(
-  router: WebhookRouter<TEventMap>,
+  router: WebhookDispatcher,
   options: ExpressAdapterOptions<TEvent>
 ): (req: Request, res: Response, next: NextFunction) => Promise<void> {
   const { verifier, onError } = options;
@@ -113,4 +112,4 @@ export function expressAdapter<
 }
 
 // Re-export core types
-export { WebhookRouter, type WebhookEvent, type EventHandler, type Middleware, type Verifier, type VerifyResult } from '@kotodayori/core';
+export { WebhookRouter, type WebhookDispatcher, type WebhookEvent, type EventHandler, type Middleware, type Verifier, type VerifyResult } from '@kotodayori/core';

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -27,7 +27,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@kotodayori/core": "workspace:*"
+    "@kotodayori/core": "workspace:^"
   },
   "devDependencies": {
     "hono": "^4.11.9",

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -31,7 +31,7 @@ export interface HonoAdapterOptions<T extends WebhookEvent = WebhookEvent> {
  * }));
  * ```
  *
- * @param router - The WebhookRouter instance
+ * @param router - A WebhookDispatcher (any object with a `dispatch(event)` method, e.g. WebhookRouter)
  * @param options - Adapter options including a verifier function
  * @returns Hono handler function
  */

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -38,7 +38,7 @@ export interface HonoAdapterOptions<T extends WebhookEvent = WebhookEvent> {
 export function honoAdapter<
   TEvent extends WebhookEvent = WebhookEvent,
 >(
-  router: WebhookDispatcher,
+  router: WebhookDispatcher<TEvent>,
   options: HonoAdapterOptions<TEvent>
 ): (c: Context) => Promise<Response> {
   const { verifier, onError } = options;

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -1,5 +1,5 @@
 import type { Context } from 'hono';
-import type { WebhookRouter, WebhookEvent, Verifier } from '@kotodayori/core';
+import type { WebhookDispatcher, WebhookEvent, Verifier } from '@kotodayori/core';
 
 /**
  * Options for the Hono adapter
@@ -36,10 +36,9 @@ export interface HonoAdapterOptions<T extends WebhookEvent = WebhookEvent> {
  * @returns Hono handler function
  */
 export function honoAdapter<
-  TEventMap extends Record<string, WebhookEvent>,
-  TEvent extends WebhookEvent = TEventMap[keyof TEventMap],
+  TEvent extends WebhookEvent = WebhookEvent,
 >(
-  router: WebhookRouter<TEventMap>,
+  router: WebhookDispatcher,
   options: HonoAdapterOptions<TEvent>
 ): (c: Context) => Promise<Response> {
   const { verifier, onError } = options;
@@ -90,4 +89,4 @@ export function honoAdapter<
 }
 
 // Re-export core types
-export { WebhookRouter, type WebhookEvent, type EventHandler, type Middleware, type Verifier, type VerifyResult } from '@kotodayori/core';
+export { WebhookRouter, type WebhookDispatcher, type WebhookEvent, type EventHandler, type Middleware, type Verifier, type VerifyResult } from '@kotodayori/core';

--- a/packages/hono/test/hono-adapter-types.test-d.ts
+++ b/packages/hono/test/hono-adapter-types.test-d.ts
@@ -40,7 +40,9 @@ describe('honoAdapter nominal decoupling', () => {
   it('accepts any structurally-compatible dispatcher (no nominal coupling to WebhookRouter)', () => {
     class ExternalRouter {
       private secret = 1; // makes it nominally distinct from WebhookRouter
-      async dispatch(_event: WebhookEvent): Promise<void> {}
+      async dispatch(event: WebhookEvent): Promise<void> {
+        void event;
+      }
     }
     const verifier: Verifier<CreatedEvent> = () => ({ event: { id: 'e', type: 'thing.created', data: { object: { id: 'x' } } } });
     const handler = honoAdapter(new ExternalRouter(), { verifier });
@@ -52,7 +54,9 @@ describe('honoAdapter nominal decoupling', () => {
     // WebhookEvent. The router param is `WebhookDispatcher<TEvent>` so this is
     // accepted; it would be rejected by a hardcoded `WebhookDispatcher<WebhookEvent>`.
     const narrowDispatcher: WebhookDispatcher<CreatedEvent> = {
-      async dispatch(_event: CreatedEvent): Promise<void> {},
+      async dispatch(event: CreatedEvent): Promise<void> {
+        void event;
+      },
     };
     const verifier: Verifier<CreatedEvent> = () => ({ event: { id: 'e', type: 'thing.created', data: { object: { id: 'x' } } } });
     const handler = honoAdapter(narrowDispatcher, { verifier });

--- a/packages/hono/test/hono-adapter-types.test-d.ts
+++ b/packages/hono/test/hono-adapter-types.test-d.ts
@@ -36,6 +36,18 @@ interface DriftEvent extends WebhookEvent {
   data: { object: unknown };
 }
 
+describe('honoAdapter nominal decoupling', () => {
+  it('accepts any structurally-compatible dispatcher (no nominal coupling to WebhookRouter)', () => {
+    class ExternalRouter {
+      private secret = 1; // makes it nominally distinct from WebhookRouter
+      async dispatch(_event: WebhookEvent): Promise<void> {}
+    }
+    const verifier: Verifier<CreatedEvent> = () => ({ event: { id: 'e', type: 'thing.created', data: { object: { id: 'x' } } } });
+    const handler = honoAdapter(new ExternalRouter(), { verifier });
+    expectTypeOf(handler).toBeFunction();
+  });
+});
+
 describe('honoAdapter generic inference', () => {
   it('accepts a typed router with a verifier whose event union matches the map', () => {
     const router = new WebhookRouter<EventMap>();

--- a/packages/hono/test/hono-adapter-types.test-d.ts
+++ b/packages/hono/test/hono-adapter-types.test-d.ts
@@ -1,6 +1,6 @@
 import { describe, it, expectTypeOf } from 'vitest';
 import { honoAdapter } from '../src/index.js';
-import { WebhookRouter, type Verifier, type WebhookEvent } from '@kotodayori/core';
+import { WebhookRouter, type Verifier, type WebhookEvent, type WebhookDispatcher } from '@kotodayori/core';
 
 /**
  * Type-level regression tests for `honoAdapter` generic inference.
@@ -44,6 +44,18 @@ describe('honoAdapter nominal decoupling', () => {
     }
     const verifier: Verifier<CreatedEvent> = () => ({ event: { id: 'e', type: 'thing.created', data: { object: { id: 'x' } } } });
     const handler = honoAdapter(new ExternalRouter(), { verifier });
+    expectTypeOf(handler).toBeFunction();
+  });
+
+  it('accepts a dispatcher narrowly typed to only the verified event (WebhookDispatcher<TEvent>)', () => {
+    // A consumer dispatcher typed to handle ONLY their verified event, not any
+    // WebhookEvent. The router param is `WebhookDispatcher<TEvent>` so this is
+    // accepted; it would be rejected by a hardcoded `WebhookDispatcher<WebhookEvent>`.
+    const narrowDispatcher: WebhookDispatcher<CreatedEvent> = {
+      async dispatch(_event: CreatedEvent): Promise<void> {},
+    };
+    const verifier: Verifier<CreatedEvent> = () => ({ event: { id: 'e', type: 'thing.created', data: { object: { id: 'x' } } } });
+    const handler = honoAdapter(narrowDispatcher, { verifier });
     expectTypeOf(handler).toBeFunction();
   });
 });

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -27,7 +27,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@kotodayori/core": "workspace:*"
+    "@kotodayori/core": "workspace:^"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.159",

--- a/packages/lambda/src/index.ts
+++ b/packages/lambda/src/index.ts
@@ -1,5 +1,5 @@
 import type { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
-import type { WebhookRouter, WebhookEvent, Verifier } from '@kotodayori/core';
+import type { WebhookDispatcher, WebhookEvent, Verifier } from '@kotodayori/core';
 
 /**
  * Options for the Lambda adapter
@@ -35,10 +35,9 @@ export interface LambdaAdapterOptions<T extends WebhookEvent = WebhookEvent> {
  * @returns Lambda handler function
  */
 export function lambdaAdapter<
-  TEventMap extends Record<string, WebhookEvent>,
-  TEvent extends WebhookEvent = TEventMap[keyof TEventMap],
+  TEvent extends WebhookEvent = WebhookEvent,
 >(
-  router: WebhookRouter<TEventMap>,
+  router: WebhookDispatcher,
   options: LambdaAdapterOptions<TEvent>
 ): (event: APIGatewayProxyEvent, context: Context) => Promise<APIGatewayProxyResult> {
   const { verifier, onError } = options;
@@ -122,4 +121,4 @@ export function lambdaAdapter<
 }
 
 // Re-export core types
-export { WebhookRouter, type WebhookEvent, type EventHandler, type Middleware, type Verifier, type VerifyResult } from '@kotodayori/core';
+export { WebhookRouter, type WebhookDispatcher, type WebhookEvent, type EventHandler, type Middleware, type Verifier, type VerifyResult } from '@kotodayori/core';

--- a/packages/lambda/src/index.ts
+++ b/packages/lambda/src/index.ts
@@ -30,7 +30,7 @@ export interface LambdaAdapterOptions<T extends WebhookEvent = WebhookEvent> {
  * });
  * ```
  *
- * @param router - The WebhookRouter instance
+ * @param router - A WebhookDispatcher (any object with a `dispatch(event)` method, e.g. WebhookRouter)
  * @param options - Adapter options including a verifier function
  * @returns Lambda handler function
  */

--- a/packages/lambda/src/index.ts
+++ b/packages/lambda/src/index.ts
@@ -37,7 +37,7 @@ export interface LambdaAdapterOptions<T extends WebhookEvent = WebhookEvent> {
 export function lambdaAdapter<
   TEvent extends WebhookEvent = WebhookEvent,
 >(
-  router: WebhookDispatcher,
+  router: WebhookDispatcher<TEvent>,
   options: LambdaAdapterOptions<TEvent>
 ): (event: APIGatewayProxyEvent, context: Context) => Promise<APIGatewayProxyResult> {
   const { verifier, onError } = options;

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -28,7 +28,7 @@
     "check-events": "tsx scripts/check-events.ts"
   },
   "dependencies": {
-    "@kotodayori/core": "workspace:*"
+    "@kotodayori/core": "workspace:^"
   },
   "devDependencies": {
     "stripe": "^20.3.1",

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -366,8 +366,8 @@ export type StripeEventType<T extends StripeEventName> = StripeEventMap[T];
 export type { Stripe };
 
 // Re-export core types and classes
-import { WebhookRouter, type WebhookEvent, type EventHandler, type Verifier, type VerifyResult } from '@kotodayori/core';
-export { WebhookRouter, type WebhookEvent, type EventHandler, type Verifier, type VerifyResult };
+import { WebhookRouter, type WebhookDispatcher, type WebhookEvent, type EventHandler, type Verifier, type VerifyResult } from '@kotodayori/core';
+export { WebhookRouter, type WebhookDispatcher, type WebhookEvent, type EventHandler, type Verifier, type VerifyResult };
 
 /**
  * Type-safe Stripe Webhook Router

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -28,7 +28,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@kotodayori/core": "workspace:*"
+    "@kotodayori/core": "workspace:^"
   },
   "peerDependencies": {
     "zod": "^4.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,7 +196,7 @@ importers:
   packages/eventbridge:
     dependencies:
       '@kotodayori/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
     devDependencies:
       '@types/aws-lambda':
@@ -215,7 +215,7 @@ importers:
   packages/express:
     dependencies:
       '@kotodayori/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
     devDependencies:
       '@types/express':
@@ -237,7 +237,7 @@ importers:
   packages/hono:
     dependencies:
       '@kotodayori/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
     devDependencies:
       hono:
@@ -256,7 +256,7 @@ importers:
   packages/lambda:
     dependencies:
       '@kotodayori/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
     devDependencies:
       '@types/aws-lambda':
@@ -275,7 +275,7 @@ importers:
   packages/stripe:
     dependencies:
       '@kotodayori/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
     devDependencies:
       stripe:
@@ -297,7 +297,7 @@ importers:
   packages/zod:
     dependencies:
       '@kotodayori/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
     devDependencies:
       tsup:


### PR DESCRIPTION
## Why

The first real-world app to adopt Kotodayori had to write this cast to pass a `StripeWebhookRouter` to the Hono adapter:

```ts
honoAdapter(webhookRouter as unknown as WebhookRouter, { verifier })(c);
```

### Root cause (investigated, not guessed)

`WebhookRouter` is a **nominal** type: its `private handlers` / `private middlewares` fields make TypeScript treat instances coming from *different installed copies* of `@kotodayori/core` as incompatible. When a consumer's `node_modules` ends up with two copies of core — e.g. `@kotodayori/hono` and `@kotodayori/stripe` resolving to different core versions because published packages pinned core via `workspace:*` (exact version, no caret) — the `StripeWebhookRouter` the user holds is not assignable to the `WebhookRouter` the adapter's signature expects, forcing `as unknown as`.

Verified by reproduction: in a single-core monorepo build, **the same code typechecks with no cast** (EXIT 0), including the app's exact custom-verifier pattern. So this is a duplicate-install + nominal-type problem, not a generics-inference problem. All adapters only ever call `router.dispatch(...)`.

## What

Defense in depth — two parts:

**A. Decouple adapters from the nominal class.** New structural interface in core:
```ts
export interface WebhookDispatcher<TEvent extends WebhookEvent = WebhookEvent> {
  dispatch(event: TEvent): Promise<void>;
}
```
Interfaces match **structurally**, so a router from any copy of core satisfies it. `WebhookRouter` now `implements WebhookDispatcher`. All four adapters (`honoAdapter`, `expressAdapter`, `lambdaAdapter`, `eventBridgeAdapter`) accept `WebhookDispatcher` for their `router` param instead of the concrete `WebhookRouter` class. Verifier-event inference (`TEvent`) is preserved independently of the router param. `WebhookDispatcher` is re-exported from every adapter and from `@kotodayori/stripe`.

**B. Prevent the duplicate install in the first place.** Internal `@kotodayori/core` dependency ranges changed from `workspace:*` to `workspace:^`, so published packages use a caret range (e.g. `^1.1.0`) and package managers can dedupe to a single core.

A type-level regression test was added to `packages/hono/test/hono-adapter-types.test-d.ts`: a class that is structurally a dispatcher but nominally distinct (has a private field) must be accepted by `honoAdapter` without a cast.

## Verification

All run on this branch:
- `pnpm -r --filter './packages/*' build` → success (all packages)
- `pnpm --filter @kotodayori/hono test` → 14 passed incl. 3 type tests (`Type Errors: no errors`), covering the new nominal-decoupling case
- core 67 / express 22 / lambda 13 / eventbridge 15 / stripe 33 → all passed, no type errors

## Files

- `packages/core/src/index.ts` — `WebhookDispatcher` interface + `implements`
- `packages/{hono,express,lambda,eventbridge}/src/index.ts` — router param → `WebhookDispatcher`, re-export
- `packages/stripe/src/index.ts` — re-export `WebhookDispatcher`
- `packages/{hono,express,lambda,eventbridge,stripe,zod}/package.json` — `workspace:*` → `workspace:^`
- `packages/hono/test/hono-adapter-types.test-d.ts` — regression test
- `.changeset/fix-adapter-nominal-router.md` — core minor, adapters/stripe patch

https://claude.ai/code/session_016w3mguJqFGoXvoDFi3uEDG

---
_Generated by [Claude Code](https://claude.ai/code/session_016w3mguJqFGoXvoDFi3uEDG)_