### PR TITLE
ci: enforce coverage in CI and add Codecov + badge (#53)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,20 @@ jobs:
       - name: Build packages for tests
         run: pnpm --filter "./packages/*" build
 
-      - name: Run tests
-        run: pnpm test
+      # Run tests with coverage so the 80% thresholds in each package's
+      # vitest.config.ts are enforced (the job fails if coverage drops below them).
+      - name: Run tests with coverage
+        run: pnpm test:coverage
+
+      # Upload per-package lcov reports to Codecov. codecov-action auto-discovers
+      # packages/*/coverage/lcov.info. Kept non-blocking so a Codecov outage
+      # does not fail CI.
+      - name: Upload coverage to Codecov
+        if: matrix.node-version == 22
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   build:
     name: Build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Kotodayori
 
+[![codecov](https://codecov.io/gh/hideokamoto/kotodayori/branch/main/graph/badge.svg)](https://codecov.io/gh/hideokamoto/kotodayori)
+
 A Hono-inspired, type-safe webhook routing library for TypeScript.
 
 ## Overview

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     environment: 'node',
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      reporter: ['text', 'json', 'html', 'lcov'],
       include: ['src/**/*.ts'],
       exclude: ['**/*.test.ts', '**/*.d.ts'],
       thresholds: {

--- a/packages/create-kotodayori/vitest.config.ts
+++ b/packages/create-kotodayori/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     environment: 'node',
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      reporter: ['text', 'json', 'html', 'lcov'],
       include: ['src/**/*.ts'],
       exclude: [
         'node_modules/',

--- a/packages/eventbridge/vitest.config.ts
+++ b/packages/eventbridge/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     environment: 'node',
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      reporter: ['text', 'json', 'html', 'lcov'],
       include: ['src/**/*.ts'],
       exclude: ['**/*.test.ts', '**/*.d.ts'],
       thresholds: {

--- a/packages/express/vitest.config.ts
+++ b/packages/express/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     environment: 'node',
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      reporter: ['text', 'json', 'html', 'lcov'],
       include: ['src/**/*.ts'],
       exclude: ['**/*.test.ts', '**/*.d.ts'],
       thresholds: {

--- a/packages/hono/vitest.config.ts
+++ b/packages/hono/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     environment: 'node',
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      reporter: ['text', 'json', 'html', 'lcov'],
       include: ['src/**/*.ts'],
       exclude: ['**/*.test.ts', '**/*.d.ts'],
       thresholds: {

--- a/packages/lambda/vitest.config.ts
+++ b/packages/lambda/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     environment: 'node',
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      reporter: ['text', 'json', 'html', 'lcov'],
       include: ['src/**/*.ts'],
       exclude: ['**/*.test.ts', '**/*.d.ts'],
       thresholds: {

--- a/packages/stripe/vitest.config.ts
+++ b/packages/stripe/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     environment: 'node',
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      reporter: ['text', 'json', 'html', 'lcov'],
       include: ['src/**/*.ts'],
       exclude: ['**/*.test.ts', '**/*.d.ts'],
       thresholds: {

--- a/packages/zod/vitest.config.ts
+++ b/packages/zod/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     environment: 'node',
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      reporter: ['text', 'json', 'html', 'lcov'],
       include: ['src/**/*.ts'],
       exclude: ['**/*.test.ts', '**/*.d.ts'],
       thresholds: {


### PR DESCRIPTION
## Summary

Implements the remaining tasks for #53 (test coverage measurement with vitest).

### Already done (prior work, untouched)
- `@vitest/coverage-v8` in root `package.json`
- All 8 packages have `vitest.config.ts` with a coverage block and 80% thresholds (lines/functions/branches/statements)
- Root script `test:coverage` = `pnpm -r test -- --coverage`; each package `test` = `vitest run`

### Changes in this PR (mapped to #53 acceptance criteria)

- **CI runs coverage + enforces thresholds** — `.github/workflows/ci.yml` test job now runs `pnpm test:coverage` instead of `pnpm test`. Because each package's `vitest.config.ts` sets 80% thresholds, the job fails when coverage drops below threshold. Integrated into the existing matrix test job (reuses checkout, pnpm setup, Node + pnpm cache, frozen-lockfile install, and the package build step).
- **LCOV reporter** — added `'lcov'` to the coverage `reporter` array in all 8 packages (`core`, `stripe`, `zod`, `eventbridge`, `create-kotodayori`, `express`, `hono`, `lambda`) so coverage services can consume the reports.
- **Codecov upload** — added a `codecov/codecov-action@v4` step after coverage generation. It runs only on the Node 22 matrix leg (avoids duplicate uploads), is non-breaking (`fail_ci_if_error: false`), and passes `token: ${{ secrets.CODECOV_TOKEN }}` (works tokenless for public repos when the secret is unset). codecov-action auto-discovers the per-package `packages/*/coverage/lcov.info` reports, so no fragile hand-rolled paths.
- **Coverage badge** — added a Codecov shields badge under the title in `README.md` (`codecov.io/gh/hideokamoto/kotodayori`, branch `main`).

### Validation
- Verified all 8 `vitest.config.ts` files now include `'lcov'`.
- Confirmed root `test:coverage` script exists.
- Validated `ci.yml` parses as valid YAML.

Closes #53

https://claude.ai/code/session_01VFV3ZHfqZ8qDLfMUTJUkww

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFV3ZHfqZ8qDLfMUTJUkww)_