### PR TITLE
docs: add PR/issue templates and changeset guide (#55)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug report
+about: Report a bug to help us improve Kotodayori
+title: "[Bug]: "
+labels: bug
+assignees: ""
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## Affected package(s)
+
+Which package(s) are affected? (e.g. `@kotodayori/core`, `@kotodayori/stripe`, `@kotodayori/hono`)
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+## Actual behavior
+
+What actually happened. Include error messages or stack traces if available.
+
+## Minimal reproduction
+
+If possible, link to a minimal reproduction (repo, gist, or code snippet).
+
+## Environment
+
+- Package version(s):
+- Node.js version:
+- pnpm version:
+- OS:
+
+## Additional context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions & Discussions
+    url: https://github.com/hideokamoto/kotodayori/discussions
+    about: Ask questions and discuss ideas with the community.
+  - name: Documentation
+    url: https://github.com/hideokamoto/kotodayori#readme
+    about: Check the README and docs before opening an issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Questions & Discussions
     url: https://github.com/hideokamoto/kotodayori/discussions

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest a new feature or enhancement for Kotodayori
+title: "[Feature]: "
+labels: enhancement
+assignees: ""
+---
+
+## Problem statement
+
+Is your feature request related to a problem? A clear and concise description of what the problem is (e.g. "I'm always frustrated when ...").
+
+## Proposed solution
+
+A clear and concise description of what you want to happen.
+
+## Affected package(s)
+
+Which package(s) would this feature affect or live in? (e.g. `@kotodayori/core`, `@kotodayori/stripe`, a new package)
+
+## Alternatives considered
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+## Additional context
+
+Add any other context, examples, or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+## Summary
+
+<!-- Brief description of what this PR does and why these changes are needed. -->
+
+## Type of change
+
+<!-- Check all that apply. -->
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that changes existing behavior)
+- [ ] Documentation only
+- [ ] Chore / internal (build, CI, refactor, tests)
+
+## Related issues
+
+<!-- Link related issues, e.g. "Closes #123" or "Relates to #123". -->
+
+## Changes
+
+<!-- List the specific changes made. -->
+
+-
+-
+
+## Testing
+
+<!-- Describe how you tested these changes. -->
+
+## Breaking changes
+
+<!-- If applicable, describe the breaking changes and the migration path. Otherwise write "None". -->
+
+## Checklist
+
+- [ ] `pnpm lint` passes
+- [ ] `pnpm test` passes
+- [ ] `pnpm typecheck` passes
+- [ ] A changeset has been added (`pnpm changeset`) if this change affects published packages
+- [ ] Documentation has been updated if needed

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,5 +36,6 @@
 - [ ] `pnpm lint` passes
 - [ ] `pnpm test` passes
 - [ ] `pnpm typecheck` passes
+- [ ] `pnpm build` passes
 - [ ] A changeset has been added (`pnpm changeset`) if this change affects published packages
 - [ ] Documentation has been updated if needed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ Thank you for your interest in contributing to Kotodayori! This document provide
 - [Testing](#testing)
 - [Code Style](#code-style)
 - [Commit Guidelines](#commit-guidelines)
+- [Creating a Changeset](#creating-a-changeset)
 - [Pull Request Process](#pull-request-process)
 - [Adding New Packages](#adding-new-packages)
 
@@ -23,7 +24,7 @@ Please be respectful and constructive in all interactions with the community. We
 
 Before contributing, please:
 
-1. Check existing [issues](https://github.com/hideokamoto/stripe-webhook-router/issues) to see if your concern is already being addressed
+1. Check existing [issues](https://github.com/hideokamoto/kotodayori/issues) to see if your concern is already being addressed
 2. For new features, open an issue first to discuss the proposed changes
 3. For bug fixes, feel free to submit a PR directly with a clear description
 
@@ -40,8 +41,8 @@ Before contributing, please:
 1. Fork and clone the repository:
 
 ```bash
-git clone https://github.com/YOUR_USERNAME/stripe-webhook-router.git
-cd stripe-webhook-router
+git clone https://github.com/YOUR_USERNAME/kotodayori.git
+cd kotodayori
 ```
 
 2. Install dependencies:
@@ -278,6 +279,47 @@ test(core): improve middleware test coverage
 chore(repo): update dependencies
 ```
 
+## Creating a Changeset
+
+We use [Changesets](https://github.com/changesets/changesets) to manage versioning and changelogs. If your change affects the published behavior of one or more packages, add a changeset to your PR.
+
+### When is a changeset needed?
+
+Add a changeset when your PR:
+
+- Adds a new feature (`minor`)
+- Fixes a bug (`patch`)
+- Introduces a breaking change (`major`)
+- Makes any other change that should appear in a package's `CHANGELOG.md`
+
+You do **not** need a changeset for changes that don't affect published packages, such as documentation, CI config, tests, or internal tooling.
+
+### How to add one
+
+From the root of the repository, run:
+
+```bash
+pnpm changeset
+```
+
+The interactive prompt will ask you to:
+
+1. **Select the affected package(s)** - choose every package your change touches.
+2. **Choose the semver bump** for each package:
+   - `patch` - bug fixes and other backwards-compatible changes
+   - `minor` - new, backwards-compatible features
+   - `major` - breaking changes
+3. **Write a summary** - this text is added to the package `CHANGELOG.md`, so write it for consumers.
+
+This creates a `.changeset/*.md` file. Commit it together with your code changes so it is included in the PR:
+
+```bash
+git add .changeset
+git commit -m "feat(core): add custom error handlers"
+```
+
+Once your PR is merged into `main`, the Changesets GitHub Action opens a "Version Packages" PR that consumes the changeset, bumps versions, and updates changelogs. See [RELEASE.md](RELEASE.md) for the full release flow.
+
 ## Pull Request Process
 
 ### Before Submitting
@@ -425,7 +467,7 @@ pnpm build
 
 If you have questions or need help:
 
-- Open a [GitHub issue](https://github.com/hideokamoto/stripe-webhook-router/issues)
+- Open a [GitHub issue](https://github.com/hideokamoto/kotodayori/issues)
 - Check existing documentation in the [README](README.md)
 - Look at existing packages for examples
 


### PR DESCRIPTION
## Summary

Completes the remaining documentation/templating tasks for issue #55, building on the changesets tooling and CONTRIBUTING.md/RELEASE.md that already landed.

## Changes

- **PR template** — Added `.github/PULL_REQUEST_TEMPLATE.md` with Summary, Type of change, Related issues, Changes, Testing, Breaking changes, and a Checklist (lint/test/typecheck pass, changeset added if needed). Based on the example PR-description block already in CONTRIBUTING.md so the two stay consistent.
- **Issue templates** — Added `.github/ISSUE_TEMPLATE/` with `bug_report.md` and `feature_request.md` (markdown front-matter: name/about/labels), plus `config.yml` with contact links. English, matching the CONTRIBUTING.md style.
- **Changeset docs** — Added a "Creating a Changeset" section to `CONTRIBUTING.md` covering `pnpm changeset`, when a changeset is needed, how to choose the semver bump, and a link to RELEASE.md for the full release flow (no duplication of RELEASE.md content).
- **Stale references** — Fixed all `stripe-webhook-router` occurrences in `CONTRIBUTING.md` (clone URL/dir and two issue links) to `kotodayori`. Verified the new template files do not reintroduce the old name.

## Mapping to issue #55 acceptance criteria

- [x] CONTRIBUTING.md (PR process + lint/test reqs) — already present
- [x] Release flow with changesets (@changesets/cli, config, CHANGELOG, release workflow, RELEASE.md) — already present
- [x] PR template
- [x] Issue templates (bug report + feature request)
- [x] "changeset の書き方" documented in CONTRIBUTING.md

## Already done (not touched by this PR)

@changesets/cli, `.changeset/config.json`, CHANGELOG auto-gen, `.github/workflows/release.yml`, the CONTRIBUTING.md body, and RELEASE.md.

Closes #55

https://claude.ai/code/session_01VFV3ZHfqZ8qDLfMUTJUkww

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFV3ZHfqZ8qDLfMUTJUkww)_