### PR TITLE
ci: automate Stripe event map sync check (scheduled + auto issue)

### DIFF
--- a/.github/workflows/stripe-events-sync.yml
+++ b/.github/workflows/stripe-events-sync.yml
@@ -1,0 +1,133 @@
+name: Stripe Events Sync
+
+# Weekly scheduled drift check for the StripeEventMap (case B).
+#
+# Unlike the `check-stripe-events` job in ci.yml (which blocks contributions on
+# push/PR — case A), this workflow catches *upstream* Stripe SDK additions even
+# when nobody pushes to the repo. On drift it opens (or comments on) a GitHub
+# issue to notify maintainers, rather than silently reddening CI.
+on:
+  schedule:
+    # Mondays 00:00 UTC.
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-stripe-events-drift:
+    name: Check Stripe Event Map Drift
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Capture the script output and exit code without failing the job, so the
+      # next step can branch on the result and open an issue.
+      - name: Check Stripe Event Map sync
+        id: check
+        continue-on-error: true
+        run: |
+          set +e
+          OUTPUT=$(pnpm --filter @kotodayori/stripe run check-events 2>&1)
+          EXIT_CODE=$?
+          echo "$OUTPUT"
+          {
+            echo 'output<<CHECK_EOF'
+            echo "$OUTPUT"
+            echo 'CHECK_EOF'
+          } >> "$GITHUB_OUTPUT"
+          echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Open issue on drift
+        if: steps.check.outputs.exit_code != '0'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = 'Stripe event map out of sync';
+            const driftLabel = 'stripe-eventmap-drift';
+            const checkOutput = process.env.CHECK_OUTPUT || '(no output captured)';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const body = [
+              'The weekly Stripe event map sync check detected drift between',
+              '`StripeEventMap` (in `packages/stripe/src/index.ts`) and the installed',
+              '`stripe` SDK type definitions.',
+              '',
+              'This usually means Stripe added (or removed) webhook event types upstream.',
+              'See `packages/stripe/MAINTAINING_STRIPE_EVENTMAP.md` for how to reconcile.',
+              '',
+              '### Check script output',
+              '',
+              '```',
+              checkOutput.trim(),
+              '```',
+              '',
+              `Triggered by [this workflow run](${runUrl}).`,
+            ].join('\n');
+
+            // Avoid duplicate issues: look for an existing OPEN issue with the
+            // dedicated drift label before creating a new one.
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: driftLabel,
+              per_page: 100,
+            });
+
+            if (existing.data.length > 0) {
+              const issue = existing.data[0];
+              core.info(`Existing drift issue found (#${issue.number}); adding a comment instead of creating a duplicate.`);
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: [
+                  'The weekly sync check still detects drift.',
+                  '',
+                  '### Latest check script output',
+                  '',
+                  '```',
+                  checkOutput.trim(),
+                  '```',
+                  '',
+                  `Triggered by [this workflow run](${runUrl}).`,
+                ].join('\n'),
+              });
+              return;
+            }
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: [driftLabel, 'area:stripe', 'type:ci', 'phase-1'],
+            });
+            core.info('Opened a new Stripe event map drift issue.');
+        env:
+          CHECK_OUTPUT: ${{ steps.check.outputs.output }}
+
+      - name: Fail the job if drift was detected
+        if: steps.check.outputs.exit_code != '0'
+        run: |
+          echo "StripeEventMap drift detected; an issue has been opened/updated."
+          exit 1

--- a/packages/stripe/MAINTAINING_STRIPE_EVENTMAP.md
+++ b/packages/stripe/MAINTAINING_STRIPE_EVENTMAP.md
@@ -50,12 +50,44 @@ When updating the `stripe` package:
 
 ## CI Integration
 
-Consider adding the check script to your CI pipeline:
+Drift between `StripeEventMap` and the Stripe SDK is detected by two
+complementary GitHub Actions mechanisms:
 
-```yaml
-# .github/workflows/ci.yml
-- name: Check Stripe events sync
-  run: pnpm run check-events
-```
+### Case A — blocking check on contributions (`ci.yml`)
 
-This will fail the build if the event map becomes out of sync with the SDK.
+The `check-stripe-events` job in `.github/workflows/ci.yml` runs
+`pnpm --filter @kotodayori/stripe run check-events` on every push and pull
+request to `main`/`develop`. If the event map is out of sync, the job (and
+therefore CI) fails, blocking the contribution until the map is reconciled.
+This catches drift introduced by a contributor (for example, bumping the
+`stripe` dependency without updating the map).
+
+### Case B — weekly auto-issue creation (`stripe-events-sync.yml`)
+
+A blocking PR check only fires when someone pushes. To also catch drift caused
+by *upstream* Stripe SDK releases when nobody is actively contributing, the
+scheduled workflow `.github/workflows/stripe-events-sync.yml` runs the same
+check **weekly** (Mondays 00:00 UTC) and can be triggered manually via
+`workflow_dispatch`.
+
+On drift it opens a GitHub issue titled "Stripe event map out of sync"
+(labels `stripe-eventmap-drift`, `area:stripe`, `type:ci`, `phase-1`) containing
+the check script output. To avoid noise it first searches for an existing open
+issue with the `stripe-eventmap-drift` label; if one exists it adds a comment
+instead of creating a duplicate. The job also ends in failure after
+opening/updating the issue, so the run is visibly red in the Actions tab — but
+the primary signal is the auto-created issue, not the red build. (Auto-issue
+creation was chosen over auto-PR creation as the right amount of automation for
+this project.)
+
+## Stripe SDK version pinning policy
+
+- The `stripe` package is pinned via the **devDependency** range in
+  `packages/stripe/package.json` (currently `^22.0.0`). This is the SDK version
+  the `check-events` script reads type definitions from.
+- The **peerDependency** range is `>=17.0.0`, so consumers may use any
+  reasonably recent Stripe SDK; the event map is maintained against the pinned
+  dev range.
+- Bumping `stripe` should be done **deliberately** (it can introduce new event
+  types), and every bump must be followed by `pnpm run check-events` (and
+  `pnpm test`) to reconcile and verify `StripeEventMap`.


### PR DESCRIPTION
## Summary

Automates detection of drift between `StripeEventMap` (`packages/stripe/src/index.ts`) and the installed Stripe SDK type definitions, using a two-mechanism policy:

- **Case A — blocking check on contributions** (already in `ci.yml`): the existing `check-stripe-events` job runs `check-events` on every push/PR to `main`/`develop` and fails CI on drift. This catches drift introduced by a contributor (e.g. bumping `stripe` without updating the map).
- **Case B — weekly auto-issue creation** (new): `.github/workflows/stripe-events-sync.yml` runs the same check weekly (Mondays 00:00 UTC) plus on-demand via `workflow_dispatch`. On drift it opens a GitHub issue titled "Stripe event map out of sync" (labels `stripe-eventmap-drift`, `area:stripe`, `type:ci`, `phase-1`) with the check script output. To avoid duplicates it first searches for an existing open issue with the `stripe-eventmap-drift` label and comments on it instead of creating a new one. The job ends in failure after opening/updating the issue, but the primary signal is the auto-created issue.

Auto-issue creation was chosen over auto-PR creation as the right level of automation for a personal project.

## Files

- `.github/workflows/stripe-events-sync.yml` — new scheduled workflow (checkout, pnpm 9.15.0, Node 22 w/ pnpm cache, frozen install, capture check output, `actions/github-script@v7` for de-duplicated issue creation; `permissions: contents: read, issues: write`).
- `packages/stripe/MAINTAINING_STRIPE_EVENTMAP.md` — replaced the tentative "CI Integration" section with the adopted case A + case B policy, and added a "Stripe SDK version pinning policy" subsection (devDependency `^22.0.0`, peerDependency `>=17.0.0`, bump deliberately + run `check-events`).

## Validation

- `pnpm install` succeeded in the worktree.
- `pnpm --filter @kotodayori/stripe run check-events` passes ("in sync", 260/260 events). No event map changes were needed.

Closes #54

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzKPSWgLnuuqbVNhgq7Ect)_