### PR TITLE
feat: scaffold @kotodayori/idempotency package

### DIFF
--- a/packages/idempotency/README.md
+++ b/packages/idempotency/README.md
@@ -1,0 +1,3 @@
+# @kotodayori/idempotency
+
+🚧 **Work in progress / scaffold.** This package will provide idempotency middleware and pluggable stores for Kotodayori webhook routing, so duplicate webhook deliveries can be detected and handled safely. The implementation lands in follow-up issues; for now this is a structural scaffold only.

--- a/packages/idempotency/package.json
+++ b/packages/idempotency/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@kotodayori/idempotency",
+  "version": "0.1.0",
+  "description": "Idempotency middleware and stores for Kotodayori webhook routing",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^25.0.0",
+    "tsup": "^8.5.1",
+    "typescript": "^6.0.0",
+    "vitest": "^4.1.8"
+  },
+  "keywords": [
+    "idempotency",
+    "webhook",
+    "stripe",
+    "typescript"
+  ],
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hideokamoto/stripe-webhook-router"
+  },
+  "homepage": "https://github.com/hideokamoto/stripe-webhook-router#readme",
+  "bugs": "https://github.com/hideokamoto/stripe-webhook-router/issues"
+}

--- a/packages/idempotency/src/index.ts
+++ b/packages/idempotency/src/index.ts
@@ -1,0 +1,15 @@
+/**
+ * @kotodayori/idempotency
+ *
+ * Idempotency middleware and stores for Kotodayori webhook routing.
+ *
+ * 🚧 Scaffold only. The real implementation (middleware + store
+ * adapters) lands in follow-up issues. The placeholder export below
+ * exists so the package builds and has something importable.
+ */
+
+/** Package name, useful for diagnostics and logging. */
+export const PACKAGE_NAME = '@kotodayori/idempotency' as const;
+
+// TODO(#57 follow-up): Replace this placeholder with the real
+// IdempotencyStore interface and middleware implementation.

--- a/packages/idempotency/test/index.test.ts
+++ b/packages/idempotency/test/index.test.ts
@@ -1,0 +1,7 @@
+import { PACKAGE_NAME } from '../src/index';
+
+describe('@kotodayori/idempotency scaffold', () => {
+  it('exposes the package name placeholder', () => {
+    expect(PACKAGE_NAME).toBe('@kotodayori/idempotency');
+  });
+});

--- a/packages/idempotency/tsconfig.json
+++ b/packages/idempotency/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/packages/idempotency/tsup.config.ts
+++ b/packages/idempotency/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+});

--- a/packages/idempotency/vitest.config.ts
+++ b/packages/idempotency/vitest.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    typecheck: {
+      enabled: true,
+      include: ['**/*.test-d.ts'],
+    },
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/*.d.ts'],
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 80,
+        statements: 80,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,21 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@7.3.0(@types/node@25.9.2)(tsx@4.22.4)(yaml@2.9.0))
 
+  packages/idempotency:
+    devDependencies:
+      '@types/node':
+        specifier: ^25.0.0
+        version: 25.9.2
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^6.0.0
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@7.3.0(@types/node@25.9.2)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/lambda:
     dependencies:
       '@kotodayori/core':


### PR DESCRIPTION
## Summary

Scaffolds a new workspace package `packages/idempotency/` (`@kotodayori/idempotency`), structurally consistent with `@kotodayori/core`. This is scaffold only — no real implementation. A minimal placeholder export and a trivial passing test are included.

## Starting version

`0.1.0` — chosen as the pre-1.0 starting point for a brand-new, unimplemented package.

## Files created

- `packages/idempotency/package.json` — name `@kotodayori/idempotency`, version `0.1.0`, description "Idempotency middleware and stores for Kotodayori webhook routing", same structural fields/scripts/devDeps/license/publishConfig/repository metadata as core. Keywords: idempotency, webhook, stripe, typescript.
- `packages/idempotency/tsconfig.json` — mirrors core (extends `../../tsconfig.base.json`, composite).
- `packages/idempotency/tsup.config.ts` — mirrors core (esm + cjs, dts, clean, sourcemap).
- `packages/idempotency/vitest.config.ts` — mirrors core (globals, node env, typecheck, v8 coverage with 80% thresholds).
- `packages/idempotency/src/index.ts` — minimal placeholder export: `export const PACKAGE_NAME = '@kotodayori/idempotency'` with a TODO noting the real `IdempotencyStore` interface and middleware land in a follow-up issue.
- `packages/idempotency/test/index.test.ts` — trivial passing test using vitest globals (matches core's `test/` directory convention).
- `packages/idempotency/README.md` — brief "🚧 work in progress / scaffold" placeholder.

Also updated `pnpm-lock.yaml` to register the new workspace importer.

The package is auto-discovered via the existing `packages/*` glob in `pnpm-workspace.yaml` and picked up by CI (`pnpm --filter "./packages/*" build` and `pnpm -r test`) without any root config changes.

## Validation (all passing)

- `pnpm install` — lockfile up to date, importer added.
- `pnpm --filter @kotodayori/idempotency build` — ESM/CJS/DTS build success.
- `pnpm --filter @kotodayori/idempotency test` — 1 file / 1 test passed, no type errors.
- `pnpm --filter @kotodayori/idempotency typecheck` — passed (`tsc --noEmit`, no errors).
- `pnpm --filter "./packages/*" build` — all packages build successfully (no regressions).

## Notes

- The sub-exports / richer `exports` map and the real `IdempotencyStore` interface + middleware implementation are intentionally deferred to later issues. This PR is structural scaffold only.
- Full README is tracked separately in #62.

Closes #57

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzKPSWgLnuuqbVNhgq7Ect)_