### PR TITLE
docs: @kotodayori/idempotency README, examples, and migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Kotodayori provides a clean, type-safe API for handling webhooks from any event 
 - `@kotodayori/express` - Express framework adapter
 - `@kotodayori/lambda` - AWS Lambda adapter
 - `@kotodayori/eventbridge` - AWS EventBridge adapter
+- `@kotodayori/idempotency` - Idempotency middleware and stores for safe duplicate-delivery handling (🚧 preview / upcoming)
 - `create-kotodayori` - Scaffolding tool for creating new projects
 
 ## Examples (monorepo)

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,9 @@
 | --- | --- |
 | `sample-hono-stripe` | Hono + Stripe 署名検証 + `StripeWebhookRouter` |
 | `sample-express-stripe` | Express + `express.raw` + `expressAdapter` |
+| `idempotency-express` | Express + `@kotodayori/idempotency` ミドルウェア（🚧 プレビュー） |
+| `idempotency-lambda` | AWS Lambda + `DynamoDBStore`（🚧 プレビュー） |
+| `idempotency-hono` | Hono + `@kotodayori/idempotency` ミドルウェア（🚧 プレビュー） |
 
 ## 再生成する場合
 

--- a/examples/idempotency-express/.env.example
+++ b/examples/idempotency-express/.env.example
@@ -1,0 +1,7 @@
+# Stripe API Keys (https://dashboard.stripe.com/apikeys)
+STRIPE_API_KEY=sk_test_...
+STRIPE_WEBHOOK_SECRET=whsec_...
+
+# Server Configuration
+PORT=3000
+NODE_ENV=development

--- a/examples/idempotency-express/.gitignore
+++ b/examples/idempotency-express/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.env
+*.log
+.DS_Store

--- a/examples/idempotency-express/README.md
+++ b/examples/idempotency-express/README.md
@@ -1,0 +1,34 @@
+# idempotency-express
+
+Express + Stripe webhook handler showing how to wire [`@kotodayori/idempotency`](../../packages/idempotency) into a Kotodayori router.
+
+> 🚧 **Preview.** `@kotodayori/idempotency` is currently a scaffold. The idempotency middleware usage in `src/index.ts` is shown as a **forward-looking / commented** example (intended v1.0 API) and is not yet implemented. The rest of the app (Express + Stripe verification + routing) runs as-is.
+
+## What it shows
+
+- Registering the idempotency middleware via `router.use(...)` **before** your handlers (see the preview block in `src/index.ts`).
+- Using `InMemoryStore` for local development and `DynamoDBStore` for production.
+- Standard Express + Stripe raw-body signature verification.
+
+## Run
+
+```bash
+# From the repo root
+pnpm install
+pnpm build
+
+cd examples/idempotency-express
+cp .env.example .env   # fill in your Stripe keys
+pnpm dev
+```
+
+Forward Stripe events locally:
+
+```bash
+stripe listen --forward-to localhost:3000/webhook
+```
+
+## Files
+
+- `src/index.ts` — app wiring + preview idempotency middleware.
+- `src/handlers/payment.ts` — example side-effecting handlers.

--- a/examples/idempotency-express/package.json
+++ b/examples/idempotency-express/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@kotodayori-examples/idempotency-express",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsup",
+    "start": "node dist/index.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@kotodayori/express": "workspace:*",
+    "@kotodayori/idempotency": "workspace:*",
+    "@kotodayori/stripe": "workspace:*",
+    "express": "^5.0.0",
+    "stripe": "^22.0.0"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.0",
+    "@types/node": "^25.0.0",
+    "tsup": "^8.5.1",
+    "tsx": "^4.22.4",
+    "typescript": "^6.0.0"
+  }
+}

--- a/examples/idempotency-express/src/handlers/payment.ts
+++ b/examples/idempotency-express/src/handlers/payment.ts
@@ -1,0 +1,18 @@
+import type { StripeWebhookRouter } from '@kotodayori/stripe';
+
+export function paymentHandlers(router: StripeWebhookRouter) {
+  // With idempotency middleware registered, this side-effecting handler
+  // runs at most once per event.id even if Stripe redelivers the event.
+  router.on('payment_intent.succeeded', async (event) => {
+    const paymentIntent = event.data.object;
+    console.log(`✅ Payment succeeded: ${paymentIntent.id}`);
+
+    // TODO: Non-idempotent side effects go here (fulfill order, send email,
+    // write a ledger row). These are exactly what idempotency protects.
+  });
+
+  router.on('payment_intent.payment_failed', async (event) => {
+    const paymentIntent = event.data.object;
+    console.log(`❌ Payment failed: ${paymentIntent.id}`);
+  });
+}

--- a/examples/idempotency-express/src/index.ts
+++ b/examples/idempotency-express/src/index.ts
@@ -1,0 +1,87 @@
+import express from 'express';
+import Stripe from 'stripe';
+import {
+  StripeWebhookRouter,
+  createStripeVerifier,
+} from '@kotodayori/stripe';
+import { expressAdapter } from '@kotodayori/express';
+// NOTE: @kotodayori/idempotency is currently a scaffold. Only `PACKAGE_NAME`
+// is exported today; the `idempotency()` middleware and stores shown in the
+// commented block below are FORWARD-LOOKING / PREVIEW (intended v1.0 API) and
+// are not yet implemented. We import the placeholder so this example stays
+// wired to the real package and typechecks against the current build.
+import { PACKAGE_NAME } from '@kotodayori/idempotency';
+import { paymentHandlers } from './handlers/payment.js';
+
+// Validate required environment variables
+if (!process.env.STRIPE_API_KEY) {
+  throw new Error('STRIPE_API_KEY environment variable is required');
+}
+if (!process.env.STRIPE_WEBHOOK_SECRET) {
+  throw new Error('STRIPE_WEBHOOK_SECRET environment variable is required');
+}
+
+const stripe = new Stripe(process.env.STRIPE_API_KEY, {
+  apiVersion: '2026-05-27.dahlia',
+});
+
+const webhookRouter = new StripeWebhookRouter();
+
+// ---------------------------------------------------------------------------
+// 🚧 PREVIEW (forward-looking, NOT yet implemented in @kotodayori/idempotency)
+//
+// Once the package is implemented, add idempotency in ~3 lines by registering
+// the middleware BEFORE your handlers so duplicate Stripe deliveries are
+// skipped automatically:
+//
+//   import { idempotency, InMemoryStore } from '@kotodayori/idempotency';
+//   webhookRouter.use(idempotency({ store: new InMemoryStore() }));
+//
+// For production use the DynamoDB-backed store instead:
+//
+//   import { idempotency, DynamoDBStore } from '@kotodayori/idempotency';
+//   import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+//   webhookRouter.use(idempotency({
+//     store: new DynamoDBStore({
+//       client: new DynamoDBClient({}),
+//       tableName: 'webhook-idempotency',
+//     }),
+//   }));
+// ---------------------------------------------------------------------------
+console.log(`[example] idempotency package: ${PACKAGE_NAME} (preview)`);
+
+// Register handlers
+paymentHandlers(webhookRouter);
+
+// Logging middleware (idempotency middleware, once implemented, would be
+// registered before this so duplicates never reach the log/handlers).
+webhookRouter.use(async (event, next) => {
+  console.log(`[${event.type}] Processing event ${event.id}`);
+  await next();
+});
+
+const app = express();
+
+app.get('/', (_req, res) => {
+  res.json({ message: 'Kotodayori Idempotency Example (Express)', status: 'running' });
+});
+
+// IMPORTANT: Use express.raw() to preserve the raw body for Stripe signature
+// verification.
+app.post(
+  '/webhook',
+  express.raw({ type: 'application/json' }),
+  expressAdapter(webhookRouter, {
+    verifier: createStripeVerifier(stripe, process.env.STRIPE_WEBHOOK_SECRET),
+    onError: async (error, event) => {
+      console.error(`Failed to process ${event?.type}:`, error);
+    },
+  })
+);
+
+const port = process.env.PORT ?? 3000;
+app.listen(port, () => {
+  console.log(`Server running on http://localhost:${port}`);
+});
+
+export default app;

--- a/examples/idempotency-express/src/index.ts
+++ b/examples/idempotency-express/src/index.ts
@@ -14,14 +14,17 @@ import { PACKAGE_NAME } from '@kotodayori/idempotency';
 import { paymentHandlers } from './handlers/payment.js';
 
 // Validate required environment variables
-if (!process.env.STRIPE_API_KEY) {
+const apiKey = process.env.STRIPE_API_KEY;
+const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+
+if (!apiKey) {
   throw new Error('STRIPE_API_KEY environment variable is required');
 }
-if (!process.env.STRIPE_WEBHOOK_SECRET) {
+if (!webhookSecret) {
   throw new Error('STRIPE_WEBHOOK_SECRET environment variable is required');
 }
 
-const stripe = new Stripe(process.env.STRIPE_API_KEY, {
+const stripe = new Stripe(apiKey, {
   apiVersion: '2026-05-27.dahlia',
 });
 
@@ -72,7 +75,7 @@ app.post(
   '/webhook',
   express.raw({ type: 'application/json' }),
   expressAdapter(webhookRouter, {
-    verifier: createStripeVerifier(stripe, process.env.STRIPE_WEBHOOK_SECRET),
+    verifier: createStripeVerifier(stripe, webhookSecret),
     onError: async (error, event) => {
       console.error(`Failed to process ${event?.type}:`, error);
     },

--- a/examples/idempotency-express/tsconfig.json
+++ b/examples/idempotency-express/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/idempotency-express/tsup.config.ts
+++ b/examples/idempotency-express/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  target: 'node18',
+  clean: true,
+  shims: true,
+});

--- a/examples/idempotency-hono/.env.example
+++ b/examples/idempotency-hono/.env.example
@@ -1,0 +1,7 @@
+# Stripe API Keys (https://dashboard.stripe.com/apikeys)
+STRIPE_API_KEY=sk_test_...
+STRIPE_WEBHOOK_SECRET=whsec_...
+
+# Server Configuration
+PORT=3000
+NODE_ENV=development

--- a/examples/idempotency-hono/.gitignore
+++ b/examples/idempotency-hono/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.env
+*.log
+.DS_Store

--- a/examples/idempotency-hono/README.md
+++ b/examples/idempotency-hono/README.md
@@ -1,0 +1,34 @@
+# idempotency-hono
+
+Hono + Stripe webhook handler showing how to wire [`@kotodayori/idempotency`](../../packages/idempotency) into a Kotodayori router.
+
+> 🚧 **Preview.** `@kotodayori/idempotency` is currently a scaffold. The idempotency middleware usage in `src/index.ts` is shown as a **forward-looking / commented** example (intended v1.0 API) and is not yet implemented. The rest of the app (Hono + Stripe verification + routing) runs as-is.
+
+## What it shows
+
+- Registering the idempotency middleware via `router.use(...)` **before** your handlers (see the preview block in `src/index.ts`).
+- Using `InMemoryStore` for local development; use a durable, shared store for edge/production.
+- Standard Hono + Stripe signature verification via `honoAdapter`.
+
+## Run
+
+```bash
+# From the repo root
+pnpm install
+pnpm build
+
+cd examples/idempotency-hono
+cp .env.example .env   # fill in your Stripe keys
+pnpm dev
+```
+
+Forward Stripe events locally:
+
+```bash
+stripe listen --forward-to localhost:3000/webhook
+```
+
+## Files
+
+- `src/index.ts` — app wiring + preview idempotency middleware.
+- `src/handlers/payment.ts` — example side-effecting handlers.

--- a/examples/idempotency-hono/package.json
+++ b/examples/idempotency-hono/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@kotodayori-examples/idempotency-hono",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsup",
+    "start": "node dist/index.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@kotodayori/hono": "workspace:*",
+    "@kotodayori/idempotency": "workspace:*",
+    "@kotodayori/stripe": "workspace:*",
+    "hono": "^4.12.23",
+    "stripe": "^22.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.0.0",
+    "tsup": "^8.5.1",
+    "tsx": "^4.22.4",
+    "typescript": "^6.0.0"
+  }
+}

--- a/examples/idempotency-hono/src/handlers/payment.ts
+++ b/examples/idempotency-hono/src/handlers/payment.ts
@@ -1,0 +1,18 @@
+import type { StripeWebhookRouter } from '@kotodayori/stripe';
+
+export function paymentHandlers(router: StripeWebhookRouter) {
+  // With idempotency middleware registered, this side-effecting handler
+  // runs at most once per event.id even if Stripe redelivers the event.
+  router.on('payment_intent.succeeded', async (event) => {
+    const paymentIntent = event.data.object;
+    console.log(`✅ Payment succeeded: ${paymentIntent.id}`);
+
+    // TODO: Non-idempotent side effects go here (fulfill order, send email,
+    // write a ledger row). These are exactly what idempotency protects.
+  });
+
+  router.on('payment_intent.payment_failed', async (event) => {
+    const paymentIntent = event.data.object;
+    console.log(`❌ Payment failed: ${paymentIntent.id}`);
+  });
+}

--- a/examples/idempotency-hono/src/index.ts
+++ b/examples/idempotency-hono/src/index.ts
@@ -13,14 +13,17 @@ import { honoAdapter } from '@kotodayori/hono';
 import { PACKAGE_NAME } from '@kotodayori/idempotency';
 import { paymentHandlers } from './handlers/payment.js';
 
-if (!process.env.STRIPE_API_KEY) {
+const apiKey = process.env.STRIPE_API_KEY;
+const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+
+if (!apiKey) {
   throw new Error('STRIPE_API_KEY environment variable is required');
 }
-if (!process.env.STRIPE_WEBHOOK_SECRET) {
+if (!webhookSecret) {
   throw new Error('STRIPE_WEBHOOK_SECRET environment variable is required');
 }
 
-const stripe = new Stripe(process.env.STRIPE_API_KEY, {
+const stripe = new Stripe(apiKey, {
   apiVersion: '2026-05-27.dahlia',
 });
 
@@ -57,7 +60,7 @@ app.get('/', (c) => {
 app.post(
   '/webhook',
   honoAdapter(webhookRouter, {
-    verifier: createStripeVerifier(stripe, process.env.STRIPE_WEBHOOK_SECRET),
+    verifier: createStripeVerifier(stripe, webhookSecret),
     onError: async (error, event) => {
       console.error(`Failed to process ${event?.type}:`, error);
     },

--- a/examples/idempotency-hono/src/index.ts
+++ b/examples/idempotency-hono/src/index.ts
@@ -1,0 +1,67 @@
+import { Hono } from 'hono';
+import Stripe from 'stripe';
+import {
+  StripeWebhookRouter,
+  createStripeVerifier,
+} from '@kotodayori/stripe';
+import { honoAdapter } from '@kotodayori/hono';
+// NOTE: @kotodayori/idempotency is currently a scaffold. Only `PACKAGE_NAME`
+// is exported today; the `idempotency()` middleware and stores shown in the
+// commented block below are FORWARD-LOOKING / PREVIEW (intended v1.0 API) and
+// are not yet implemented. We import the placeholder so this example stays
+// wired to the real package and typechecks against the current build.
+import { PACKAGE_NAME } from '@kotodayori/idempotency';
+import { paymentHandlers } from './handlers/payment.js';
+
+if (!process.env.STRIPE_API_KEY) {
+  throw new Error('STRIPE_API_KEY environment variable is required');
+}
+if (!process.env.STRIPE_WEBHOOK_SECRET) {
+  throw new Error('STRIPE_WEBHOOK_SECRET environment variable is required');
+}
+
+const stripe = new Stripe(process.env.STRIPE_API_KEY, {
+  apiVersion: '2026-05-27.dahlia',
+});
+
+const webhookRouter = new StripeWebhookRouter();
+
+// ---------------------------------------------------------------------------
+// 🚧 PREVIEW (forward-looking, NOT yet implemented in @kotodayori/idempotency)
+//
+// Once the package is implemented, add idempotency in ~3 lines by registering
+// the middleware BEFORE your handlers so duplicate Stripe deliveries are
+// skipped automatically:
+//
+//   import { idempotency, InMemoryStore } from '@kotodayori/idempotency';
+//   webhookRouter.use(idempotency({ store: new InMemoryStore() }));
+//
+// For production / edge deployments use a durable, shared store (e.g. the
+// DynamoDB-backed store) instead of the in-memory one.
+// ---------------------------------------------------------------------------
+console.log(`[example] idempotency package: ${PACKAGE_NAME} (preview)`);
+
+paymentHandlers(webhookRouter);
+
+webhookRouter.use(async (event, next) => {
+  console.log(`[${event.type}] Processing event ${event.id}`);
+  await next();
+});
+
+const app = new Hono();
+
+app.get('/', (c) => {
+  return c.json({ message: 'Kotodayori Idempotency Example (Hono)', status: 'running' });
+});
+
+app.post(
+  '/webhook',
+  honoAdapter(webhookRouter, {
+    verifier: createStripeVerifier(stripe, process.env.STRIPE_WEBHOOK_SECRET),
+    onError: async (error, event) => {
+      console.error(`Failed to process ${event?.type}:`, error);
+    },
+  })
+);
+
+export default app;

--- a/examples/idempotency-hono/tsconfig.json
+++ b/examples/idempotency-hono/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/idempotency-hono/tsup.config.ts
+++ b/examples/idempotency-hono/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  target: 'node18',
+  clean: true,
+  shims: true,
+});

--- a/examples/idempotency-lambda/.env.example
+++ b/examples/idempotency-lambda/.env.example
@@ -1,0 +1,6 @@
+# Stripe API Keys (https://dashboard.stripe.com/apikeys)
+STRIPE_API_KEY=sk_test_...
+STRIPE_WEBHOOK_SECRET=whsec_...
+
+# DynamoDB table used by the (preview) DynamoDBStore
+IDEMPOTENCY_TABLE_NAME=webhook-idempotency

--- a/examples/idempotency-lambda/.gitignore
+++ b/examples/idempotency-lambda/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.env
+*.log
+.DS_Store

--- a/examples/idempotency-lambda/README.md
+++ b/examples/idempotency-lambda/README.md
@@ -1,0 +1,29 @@
+# idempotency-lambda
+
+AWS Lambda + Stripe webhook handler showing how to wire [`@kotodayori/idempotency`](../../packages/idempotency) into a Kotodayori router using a durable, shared store.
+
+> 🚧 **Preview.** `@kotodayori/idempotency` is currently a scaffold. The idempotency middleware + `DynamoDBStore` usage in `src/index.ts` is shown as a **forward-looking / commented** example (intended v1.0 API) and is not yet implemented. The rest of the handler (Lambda + Stripe verification + routing) runs as-is.
+
+## What it shows
+
+- Why Lambda especially needs idempotency: invocations scale horizontally and retry, so a **shared, durable** store (DynamoDB) is the right choice.
+- Registering the idempotency middleware via `router.use(...)` **before** your handlers (see the preview block in `src/index.ts`).
+- `DynamoDBStore` configuration including an optional TTL for auto-expiring processed records.
+
+## Build
+
+```bash
+# From the repo root
+pnpm install
+pnpm build
+
+cd examples/idempotency-lambda
+pnpm build   # outputs dist/index.js — deploy as your Lambda handler (handler = "index.handler")
+```
+
+Set `STRIPE_API_KEY`, `STRIPE_WEBHOOK_SECRET`, and (for the preview store) `IDEMPOTENCY_TABLE_NAME` in the Lambda environment. The DynamoDB table needs a String partition key; enable TTL on the store's expiry attribute if you use `ttlSeconds`.
+
+## Files
+
+- `src/index.ts` — Lambda handler wiring + preview idempotency middleware (DynamoDBStore).
+- `src/handlers/payment.ts` — example side-effecting handlers.

--- a/examples/idempotency-lambda/package.json
+++ b/examples/idempotency-lambda/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@kotodayori-examples/idempotency-lambda",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@kotodayori/idempotency": "workspace:*",
+    "@kotodayori/lambda": "workspace:*",
+    "@kotodayori/stripe": "workspace:*",
+    "stripe": "^22.0.0"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.145",
+    "@types/node": "^25.0.0",
+    "tsup": "^8.5.1",
+    "typescript": "^6.0.0"
+  }
+}

--- a/examples/idempotency-lambda/src/handlers/payment.ts
+++ b/examples/idempotency-lambda/src/handlers/payment.ts
@@ -1,0 +1,20 @@
+import type { StripeWebhookRouter } from '@kotodayori/stripe';
+
+export function paymentHandlers(router: StripeWebhookRouter) {
+  // With idempotency middleware registered, this side-effecting handler
+  // runs at most once per event.id even if Stripe redelivers the event.
+  // This is especially important for Lambda, where retries and concurrent
+  // invocations across instances are common.
+  router.on('payment_intent.succeeded', async (event) => {
+    const paymentIntent = event.data.object;
+    console.log(`✅ Payment succeeded: ${paymentIntent.id}`);
+
+    // TODO: Non-idempotent side effects go here (fulfill order, send email,
+    // write a ledger row). These are exactly what idempotency protects.
+  });
+
+  router.on('payment_intent.payment_failed', async (event) => {
+    const paymentIntent = event.data.object;
+    console.log(`❌ Payment failed: ${paymentIntent.id}`);
+  });
+}

--- a/examples/idempotency-lambda/src/index.ts
+++ b/examples/idempotency-lambda/src/index.ts
@@ -1,0 +1,55 @@
+import Stripe from 'stripe';
+import {
+  StripeWebhookRouter,
+  createStripeVerifier,
+} from '@kotodayori/stripe';
+import { lambdaAdapter } from '@kotodayori/lambda';
+// NOTE: @kotodayori/idempotency is currently a scaffold. Only `PACKAGE_NAME`
+// is exported today; the `idempotency()` middleware and `DynamoDBStore` shown
+// in the commented block below are FORWARD-LOOKING / PREVIEW (intended v1.0
+// API) and are not yet implemented. We import the placeholder so this example
+// stays wired to the real package and typechecks against the current build.
+import { PACKAGE_NAME } from '@kotodayori/idempotency';
+import { paymentHandlers } from './handlers/payment.js';
+
+if (!process.env.STRIPE_API_KEY) {
+  throw new Error('STRIPE_API_KEY environment variable is required');
+}
+if (!process.env.STRIPE_WEBHOOK_SECRET) {
+  throw new Error('STRIPE_WEBHOOK_SECRET environment variable is required');
+}
+
+const stripe = new Stripe(process.env.STRIPE_API_KEY, {
+  apiVersion: '2026-05-27.dahlia',
+});
+
+const webhookRouter = new StripeWebhookRouter();
+
+// ---------------------------------------------------------------------------
+// 🚧 PREVIEW (forward-looking, NOT yet implemented in @kotodayori/idempotency)
+//
+// On Lambda you almost always want a DURABLE, SHARED store because invocations
+// scale horizontally and retry. Once the package is implemented, register the
+// DynamoDB-backed store BEFORE your handlers:
+//
+//   import { idempotency, DynamoDBStore } from '@kotodayori/idempotency';
+//   import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+//
+//   webhookRouter.use(idempotency({
+//     store: new DynamoDBStore({
+//       client: new DynamoDBClient({}),
+//       tableName: process.env.IDEMPOTENCY_TABLE_NAME ?? 'webhook-idempotency',
+//       ttlSeconds: 60 * 60 * 24 * 7, // expire processed records after 7 days
+//     }),
+//   }));
+// ---------------------------------------------------------------------------
+console.log(`[example] idempotency package: ${PACKAGE_NAME} (preview)`);
+
+paymentHandlers(webhookRouter);
+
+export const handler = lambdaAdapter(webhookRouter, {
+  verifier: createStripeVerifier(stripe, process.env.STRIPE_WEBHOOK_SECRET),
+  onError: async (error, event) => {
+    console.error(`Failed to process ${event?.type}:`, error);
+  },
+});

--- a/examples/idempotency-lambda/src/index.ts
+++ b/examples/idempotency-lambda/src/index.ts
@@ -12,14 +12,17 @@ import { lambdaAdapter } from '@kotodayori/lambda';
 import { PACKAGE_NAME } from '@kotodayori/idempotency';
 import { paymentHandlers } from './handlers/payment.js';
 
-if (!process.env.STRIPE_API_KEY) {
+const apiKey = process.env.STRIPE_API_KEY;
+const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+
+if (!apiKey) {
   throw new Error('STRIPE_API_KEY environment variable is required');
 }
-if (!process.env.STRIPE_WEBHOOK_SECRET) {
+if (!webhookSecret) {
   throw new Error('STRIPE_WEBHOOK_SECRET environment variable is required');
 }
 
-const stripe = new Stripe(process.env.STRIPE_API_KEY, {
+const stripe = new Stripe(apiKey, {
   apiVersion: '2026-05-27.dahlia',
 });
 
@@ -48,7 +51,7 @@ console.log(`[example] idempotency package: ${PACKAGE_NAME} (preview)`);
 paymentHandlers(webhookRouter);
 
 export const handler = lambdaAdapter(webhookRouter, {
-  verifier: createStripeVerifier(stripe, process.env.STRIPE_WEBHOOK_SECRET),
+  verifier: createStripeVerifier(stripe, webhookSecret),
   onError: async (error, event) => {
     console.error(`Failed to process ${event?.type}:`, error);
   },

--- a/examples/idempotency-lambda/tsconfig.json
+++ b/examples/idempotency-lambda/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/idempotency-lambda/tsup.config.ts
+++ b/examples/idempotency-lambda/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  target: 'node18',
+  clean: true,
+  shims: true,
+});

--- a/packages/idempotency/MIGRATION.md
+++ b/packages/idempotency/MIGRATION.md
@@ -1,0 +1,43 @@
+# Migration: add `@kotodayori/idempotency` to an existing app
+
+> 🚧 **Preview / forward-looking.** The `idempotency`, `InMemoryStore`, and `DynamoDBStore` exports are the **intended v1.0 design** and are **not yet implemented**. The snippets below are illustrative.
+
+Adding idempotency to an existing Kotodayori router is roughly **3 lines**: install, create a store, register one middleware. No handler changes are required.
+
+## 1. Install
+
+```bash
+pnpm add @kotodayori/idempotency
+# For the DynamoDB store (production / multi-instance):
+pnpm add @aws-sdk/client-dynamodb
+```
+
+## 2. Add the middleware (before your handlers)
+
+```diff
+  import { StripeWebhookRouter } from '@kotodayori/stripe';
++ import { idempotency, DynamoDBStore } from '@kotodayori/idempotency';
++ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+
+  const router = new StripeWebhookRouter();
+
++ router.use(idempotency({
++   store: new DynamoDBStore({ client: new DynamoDBClient({}), tableName: 'webhook-idempotency' }),
++ }));
+
+  router.on('payment_intent.succeeded', async (event) => { /* unchanged */ });
+```
+
+For local development, swap `DynamoDBStore` for `InMemoryStore` (no external dependencies):
+
+```typescript
+import { idempotency, InMemoryStore } from '@kotodayori/idempotency';
+
+router.use(idempotency({ store: new InMemoryStore() }));
+```
+
+## Notes
+
+- Register the middleware **before** `router.on(...)` so it guards every event.
+- The middleware keys on the event's unique ID (`event.id` for Stripe); duplicates are skipped automatically.
+- See the package [README](./README.md) for store selection guidance and TTL configuration.

--- a/packages/idempotency/README.ja.md
+++ b/packages/idempotency/README.ja.md
@@ -1,0 +1,167 @@
+[English](./README.md) | **日本語**
+
+# @kotodayori/idempotency
+
+[Kotodayori](https://github.com/hideokamoto/kotodayori) の Webhook ルーティング向けの冪等性（idempotency）ミドルウェアと差し替え可能なストアです。Webhook の重複配信を検知し、安全に処理できるようにします。
+
+> 🚧 **プレビュー / 先行ドキュメント。** このパッケージは現時点では構造的なスキャフォルドのみです。以下で説明する API は **v1.0 で予定している設計** であり、**まだ実装されていません**。コード例はあくまで説明用で、実装が後続の Issue で追加されるまではそのままでは動作しません。未実装の API を参照している箇所には *プレビュー* と明記しています。
+
+## なぜ必要か
+
+Stripe をはじめとする Webhook プロバイダは **「ちょうど 1 回（exactly-once）」の配信を保証しません**。同じイベント（同一の `event.id`）が、次のような理由で複数回配信されることがあります。
+
+- ネットワークのタイムアウトとリトライ（Stripe は `2xx` を受け取るまで再送します）。
+- プロバイダ側の at-least-once（最低 1 回）配信セマンティクス。
+- ロードバランサやプロキシによるリクエストの再送。
+
+ハンドラに副作用がある場合 — 課金、アクセス権の付与、メール送信、台帳への書き込みなど — 同じイベントを 2 回処理すると **二重処理**（メールの重複送信、二重出荷、残高の不整合）が発生します。
+
+`@kotodayori/idempotency` は処理済みのイベントを記録し、重複を早期に打ち切ることで、各イベントのハンドラ実行を **最大 1 回** に抑えます。
+
+## 使うべきとき
+
+次のいずれかに当てはまる場合は冪等性を導入してください。
+
+- ハンドラが **冪等でない副作用**（課金、出荷、メール、外部 API 呼び出し）を行う。
+- Webhook エンドポイントを **複数インスタンス** で動かしており（水平スケール）、処理済みイベントの共有された永続的な記録が必要。
+- ビジネスロジックが「ほぼ」冪等であっても、多層防御を入れておきたい。
+
+## 不要なとき
+
+次の場合は省略できます。
+
+- ハンドラが **本質的に冪等**（安定した ID をキーにした純粋な `UPSERT`、または最新状態へのキャッシュ更新のみ）。
+- 副作用のない **ログ出力** のみを行っている。
+- データストア側で書き込み時点で event ID の一意性をすでに強制している（その場合、ここでの冪等性は任意の保険です）。
+
+## インストール
+
+```bash
+npm install @kotodayori/idempotency
+# または
+pnpm add @kotodayori/idempotency
+# または
+yarn add @kotodayori/idempotency
+```
+
+本番（複数インスタンス）向けには、DynamoDB ストアの peer dependency も必要です。
+
+```bash
+pnpm add @aws-sdk/client-dynamodb
+```
+
+## クイックスタート
+
+> ⚠️ **プレビュー:** 以下の `idempotency` とストアの export は先行公開であり、まだ実装されていません。
+
+このパッケージは Kotodayori の標準ミドルウェアとして `router.use(...)` 経由で統合します。ディスパッチされるすべてのイベントをラップできるよう、ハンドラ登録の **前** に登録してください。
+
+```typescript
+// 🚧 プレビュー — v1.0 で予定している API。まだ未実装です。
+import { StripeWebhookRouter, createStripeVerifier } from '@kotodayori/stripe';
+import { expressAdapter } from '@kotodayori/express';
+import { idempotency, InMemoryStore } from '@kotodayori/idempotency';
+
+const router = new StripeWebhookRouter();
+
+// すべてのハンドラを保護できるよう、冪等性ミドルウェアを最初に登録します。
+router.use(idempotency({ store: new InMemoryStore() }));
+
+// ハンドラは event.id ごとに最大 1 回だけ実行されます。
+router.on('payment_intent.succeeded', async (event) => {
+  await fulfillOrder(event.data.object);
+});
+```
+
+ミドルウェアの動作:
+
+1. イベントの一意キー（Stripe では `event.id`）を読み取る。
+2. ストアを検索する。
+3. すでに処理済みなら、後続のハンドラ（および `next()`）を **スキップ** する。
+4. そうでなければハンドラを実行し、完了後にキーをストアへ記録する。
+
+## ストアの選び方
+
+ミドルウェアはストア非依存です。標準で 2 つのストアを同梱しており、`IdempotencyStore` インターフェースに沿って独自実装も可能です。
+
+| ストア | 向いている用途 | 永続性 | インスタンス間共有 |
+| --- | --- | --- | --- |
+| `InMemoryStore` | ローカル開発、テスト、単一プロセス | 再起動で消失 | ❌ なし |
+| `DynamoDBStore` | 本番、サーバーレス、複数インスタンス | 永続 | ✅ あり |
+
+### InMemoryStore
+
+設定不要・外部依存なし。開発やテストに適しています。処理済みイベントの集合が共有されず再起動で失われるため、複数インスタンスの本番には **適しません**。
+
+```typescript
+// 🚧 プレビュー
+import { idempotency, InMemoryStore } from '@kotodayori/idempotency';
+
+router.use(idempotency({ store: new InMemoryStore() }));
+```
+
+### DynamoDBStore
+
+永続的でインスタンス間で共有されます。本番やサーバーレス（AWS Lambda）で推奨されるストアです。処理済みイベントごとに 1 アイテムを保存し、DynamoDB の TTL 属性を使って古いレコードを自動的に失効させることもできます。
+
+```typescript
+// 🚧 プレビュー
+import { idempotency, DynamoDBStore } from '@kotodayori/idempotency';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+
+const store = new DynamoDBStore({
+  client: new DynamoDBClient({}),
+  tableName: 'webhook-idempotency',
+  // 任意: N 秒後に処理済みレコードを自動失効させます。
+  ttlSeconds: 60 * 60 * 24 * 7, // 7 日
+});
+
+router.use(idempotency({ store }));
+```
+
+DynamoDB テーブルにはパーティションキー（例: `String` 型の `pk`）が必要です。`ttlSeconds` を有効にする場合は、ストアが書き込む属性（例: `expiresAt`）に対してテーブルの TTL を設定してください。
+
+## マイグレーション: 既存ルーターへの追加
+
+> 🚧 **プレビュー** — 以下の API は先行公開です。[`MIGRATION.md`](./MIGRATION.md) も参照してください。
+
+すでに動作している Kotodayori ルーターがあれば、import の追加・ストアの生成・ミドルウェア 1 つの登録だけで済みます。
+
+```diff
+  import { StripeWebhookRouter, createStripeVerifier } from '@kotodayori/stripe';
+  import { expressAdapter } from '@kotodayori/express';
++ import { idempotency, DynamoDBStore } from '@kotodayori/idempotency';
++ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+
+  const router = new StripeWebhookRouter();
+
++ // すべてのイベントを保護できるよう、ハンドラの前に登録します。
++ router.use(idempotency({
++   store: new DynamoDBStore({ client: new DynamoDBClient({}), tableName: 'webhook-idempotency' }),
++ }));
+
+  router.on('payment_intent.succeeded', async (event) => { /* ... */ });
+```
+
+これだけです。ハンドラの変更は不要です。ローカル開発では `DynamoDBStore` の代わりに `InMemoryStore` を使ってください。
+
+## サンプル
+
+実行可能なプレビュー用サンプルは [`examples/`](../../examples) 配下にあります。
+
+- [`examples/idempotency-express`](../../examples/idempotency-express) — Express + 冪等性ミドルウェア。
+- [`examples/idempotency-lambda`](../../examples/idempotency-lambda) — AWS Lambda + `DynamoDBStore`。
+- [`examples/idempotency-hono`](../../examples/idempotency-hono) — Hono + 冪等性ミドルウェア。
+
+## ステータス
+
+| 機能 | ステータス |
+| --- | --- |
+| `idempotency()` ミドルウェア | 🚧 予定 (v1.0) |
+| `IdempotencyStore` インターフェース | 🚧 予定 (v1.0) |
+| `InMemoryStore` | 🚧 予定 (v1.0) |
+| `DynamoDBStore` | 🚧 予定 (v1.0) |
+
+## ライセンス
+
+MIT

--- a/packages/idempotency/README.md
+++ b/packages/idempotency/README.md
@@ -1,3 +1,167 @@
+**English** | [日本語](./README.ja.md)
+
 # @kotodayori/idempotency
 
-🚧 **Work in progress / scaffold.** This package will provide idempotency middleware and pluggable stores for Kotodayori webhook routing, so duplicate webhook deliveries can be detected and handled safely. The implementation lands in follow-up issues; for now this is a structural scaffold only.
+Idempotency middleware and pluggable stores for [Kotodayori](https://github.com/hideokamoto/kotodayori) webhook routing, so duplicate webhook deliveries can be detected and handled safely.
+
+> 🚧 **Preview / forward-looking docs.** The package is currently a structural scaffold. The API described below is the **intended v1.0 design** and is **not yet implemented** — code snippets are illustrative and will not run as-is until the implementation lands in follow-up issues. Anything that references an unimplemented API is marked as *preview*.
+
+## Why you need it
+
+Webhook providers like Stripe **do not guarantee exactly-once delivery**. The same event (same `event.id`) can be delivered more than once because of:
+
+- Network timeouts and retries (Stripe retries until it receives a `2xx`).
+- Provider-side at-least-once delivery semantics.
+- Load balancers or proxies replaying a request.
+
+If your handler has side effects — charging a customer, provisioning access, sending an email, writing a ledger row — processing the same event twice causes **double-processing** (duplicate emails, double fulfillment, corrupted balances).
+
+`@kotodayori/idempotency` records which events have already been processed and short-circuits duplicates, so each event runs your handlers **at most once**.
+
+## When to use it
+
+Use idempotency when **any** of the following is true:
+
+- Your handlers perform **non-idempotent side effects** (payments, fulfillment, emails, external API calls).
+- You run **multiple instances** of your webhook endpoint (horizontal scaling) and need a shared, durable record of processed events.
+- You want defense-in-depth even though your business logic is "mostly" idempotent.
+
+## When you DON'T need it
+
+You can skip it when:
+
+- Your handlers are **naturally idempotent** (e.g. a pure `UPSERT` keyed by a stable ID, or simply updating a cache to the latest state).
+- You only **log** events with no downstream side effects.
+- Your datastore already enforces uniqueness on the event ID at the point of write (in that case idempotency here is optional belt-and-suspenders).
+
+## Installation
+
+```bash
+npm install @kotodayori/idempotency
+# or
+pnpm add @kotodayori/idempotency
+# or
+yarn add @kotodayori/idempotency
+```
+
+For production (multi-instance) deployments you'll also want the DynamoDB store's peer dependency:
+
+```bash
+pnpm add @aws-sdk/client-dynamodb
+```
+
+## Quick start
+
+> ⚠️ **Preview:** `idempotency` and the store exports below are forward-looking and not yet implemented.
+
+The package integrates as a standard Kotodayori middleware via `router.use(...)`. Register it **before** your handlers so it can wrap every dispatched event:
+
+```typescript
+// 🚧 PREVIEW — intended v1.0 API, not yet implemented.
+import { StripeWebhookRouter, createStripeVerifier } from '@kotodayori/stripe';
+import { expressAdapter } from '@kotodayori/express';
+import { idempotency, InMemoryStore } from '@kotodayori/idempotency';
+
+const router = new StripeWebhookRouter();
+
+// Register idempotency middleware FIRST so it guards every handler.
+router.use(idempotency({ store: new InMemoryStore() }));
+
+// Your handlers run at most once per event.id.
+router.on('payment_intent.succeeded', async (event) => {
+  await fulfillOrder(event.data.object);
+});
+```
+
+The middleware:
+
+1. Reads the event's unique key (`event.id` for Stripe).
+2. Looks it up in the store.
+3. If already processed, **skips** the downstream handlers (and `next()`).
+4. Otherwise runs the handlers, then records the key in the store.
+
+## Choosing a store
+
+The middleware is store-agnostic. Two stores ship in the box, and you can implement your own against the `IdempotencyStore` interface.
+
+| Store | Best for | Durability | Shared across instances |
+| --- | --- | --- | --- |
+| `InMemoryStore` | Local dev, tests, single-process apps | Lost on restart | ❌ No |
+| `DynamoDBStore` | Production, serverless, multi-instance | Durable | ✅ Yes |
+
+### InMemoryStore
+
+Zero-config, no external dependencies. Good for development and tests. **Not** suitable for production with more than one instance, because the processed-event set is not shared and is lost on restart.
+
+```typescript
+// 🚧 PREVIEW
+import { idempotency, InMemoryStore } from '@kotodayori/idempotency';
+
+router.use(idempotency({ store: new InMemoryStore() }));
+```
+
+### DynamoDBStore
+
+Durable and shared across instances — the recommended choice for production and serverless (AWS Lambda). It stores one item per processed event and can use a DynamoDB TTL attribute to expire old records automatically.
+
+```typescript
+// 🚧 PREVIEW
+import { idempotency, DynamoDBStore } from '@kotodayori/idempotency';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+
+const store = new DynamoDBStore({
+  client: new DynamoDBClient({}),
+  tableName: 'webhook-idempotency',
+  // Optional: auto-expire processed records after N seconds.
+  ttlSeconds: 60 * 60 * 24 * 7, // 7 days
+});
+
+router.use(idempotency({ store }));
+```
+
+The DynamoDB table needs a partition key (e.g. `pk` of type String). If you enable `ttlSeconds`, configure the table's TTL on the attribute the store writes (e.g. `expiresAt`).
+
+## Migration: add idempotency to an existing router
+
+> 🚧 **Preview** — the API below is forward-looking. See also [`MIGRATION.md`](./MIGRATION.md).
+
+If you already have a working Kotodayori router, you only need to add an import, create a store, and register one middleware:
+
+```diff
+  import { StripeWebhookRouter, createStripeVerifier } from '@kotodayori/stripe';
+  import { expressAdapter } from '@kotodayori/express';
++ import { idempotency, DynamoDBStore } from '@kotodayori/idempotency';
++ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+
+  const router = new StripeWebhookRouter();
+
++ // Register BEFORE your handlers so it guards every event.
++ router.use(idempotency({
++   store: new DynamoDBStore({ client: new DynamoDBClient({}), tableName: 'webhook-idempotency' }),
++ }));
+
+  router.on('payment_intent.succeeded', async (event) => { /* ... */ });
+```
+
+That's it — no handler changes required. Use `InMemoryStore` instead of `DynamoDBStore` for local development.
+
+## Examples
+
+Runnable preview examples live under [`examples/`](../../examples):
+
+- [`examples/idempotency-express`](../../examples/idempotency-express) — Express + idempotency middleware.
+- [`examples/idempotency-lambda`](../../examples/idempotency-lambda) — AWS Lambda + `DynamoDBStore`.
+- [`examples/idempotency-hono`](../../examples/idempotency-hono) — Hono + idempotency middleware.
+
+## Status
+
+| Capability | Status |
+| --- | --- |
+| `idempotency()` middleware | 🚧 Planned (v1.0) |
+| `IdempotencyStore` interface | 🚧 Planned (v1.0) |
+| `InMemoryStore` | 🚧 Planned (v1.0) |
+| `DynamoDBStore` | 🚧 Planned (v1.0) |
+
+## License
+
+MIT

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,99 @@ importers:
         specifier: ^4.98.0
         version: 4.98.0
 
+  examples/idempotency-express:
+    dependencies:
+      '@kotodayori/express':
+        specifier: workspace:*
+        version: link:../../packages/express
+      '@kotodayori/idempotency':
+        specifier: workspace:*
+        version: link:../../packages/idempotency
+      '@kotodayori/stripe':
+        specifier: workspace:*
+        version: link:../../packages/stripe
+      express:
+        specifier: ^5.0.0
+        version: 5.2.1
+      stripe:
+        specifier: ^22.0.0
+        version: 22.2.0(@types/node@25.9.2)
+    devDependencies:
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.6
+      '@types/node':
+        specifier: ^25.0.0
+        version: 25.9.2
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
+      typescript:
+        specifier: ^6.0.0
+        version: 6.0.3
+
+  examples/idempotency-hono:
+    dependencies:
+      '@kotodayori/hono':
+        specifier: workspace:*
+        version: link:../../packages/hono
+      '@kotodayori/idempotency':
+        specifier: workspace:*
+        version: link:../../packages/idempotency
+      '@kotodayori/stripe':
+        specifier: workspace:*
+        version: link:../../packages/stripe
+      hono:
+        specifier: ^4.12.23
+        version: 4.12.23
+      stripe:
+        specifier: ^22.0.0
+        version: 22.2.0(@types/node@25.9.2)
+    devDependencies:
+      '@types/node':
+        specifier: ^25.0.0
+        version: 25.9.2
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
+      typescript:
+        specifier: ^6.0.0
+        version: 6.0.3
+
+  examples/idempotency-lambda:
+    dependencies:
+      '@kotodayori/idempotency':
+        specifier: workspace:*
+        version: link:../../packages/idempotency
+      '@kotodayori/lambda':
+        specifier: workspace:*
+        version: link:../../packages/lambda
+      '@kotodayori/stripe':
+        specifier: workspace:*
+        version: link:../../packages/stripe
+      stripe:
+        specifier: ^22.0.0
+        version: 22.2.0(@types/node@25.9.2)
+    devDependencies:
+      '@types/aws-lambda':
+        specifier: ^8.10.145
+        version: 8.10.162
+      '@types/node':
+        specifier: ^25.0.0
+        version: 25.9.2
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^6.0.0
+        version: 6.0.3
+
   examples/sample-express-stripe:
     dependencies:
       '@kotodayori/express':

--- a/tsconfig.typedoc.json
+++ b/tsconfig.typedoc.json
@@ -9,7 +9,8 @@
       "@kotodayori/hono": ["./packages/hono/src/index.ts"],
       "@kotodayori/express": ["./packages/express/src/index.ts"],
       "@kotodayori/lambda": ["./packages/lambda/src/index.ts"],
-      "@kotodayori/eventbridge": ["./packages/eventbridge/src/index.ts"]
+      "@kotodayori/eventbridge": ["./packages/eventbridge/src/index.ts"],
+      "@kotodayori/idempotency": ["./packages/idempotency/src/index.ts"]
     }
   },
   "include": [
@@ -19,7 +20,8 @@
     "packages/hono/src/**/*",
     "packages/express/src/**/*",
     "packages/lambda/src/**/*",
-    "packages/eventbridge/src/**/*"
+    "packages/eventbridge/src/**/*",
+    "packages/idempotency/src/**/*"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary

Documentation, examples, and a migration guide for `@kotodayori/idempotency`.

> **Stacked PR.** This branch is stacked on #57 (PR #86, `claude/issue-57-idempotency-scaffold`), which adds the `packages/idempotency/` scaffold. Its base is therefore `claude/issue-57-idempotency-scaffold`, **not `main`**, so this diff shows only the docs/examples work. **Merge this after #86.**

> **Forward-looking / preview.** The idempotency package is currently a scaffold (only `PACKAGE_NAME` is exported; the `idempotency()` middleware, `IdempotencyStore` interface, `InMemoryStore`, and `DynamoDBStore` are not implemented yet — they land in later issues). All API usage in these docs/examples is the **intended v1.0 design** and is clearly marked as preview. Example apps import the existing placeholder export so they typecheck/build today; the forward-looking middleware wiring is shown in comments and READMEs rather than compiled `.ts`, so CI stays green.

## Files

- `packages/idempotency/README.md` — real English README: why idempotency is needed (Stripe at-least-once delivery / duplicate webhooks), when to use it vs. when you don't, installation, `router.use(...)` quick start, InMemoryStore vs DynamoDBStore selection guidance, migration section. Adds `**English** | [日本語](./README.ja.md)` language switch.
- `packages/idempotency/README.ja.md` — Japanese translation with `[English](./README.md) | **日本語**` switch.
- `packages/idempotency/MIGRATION.md` — concise "~3 lines" migration guide for existing users.
- `examples/idempotency-express/` — Express example (package.json with `workspace:*` deps, README, src wiring).
- `examples/idempotency-lambda/` — AWS Lambda example with `DynamoDBStore` (preview).
- `examples/idempotency-hono/` — Hono example.
- `README.md` (root) — added `@kotodayori/idempotency` to the package list, marked preview/upcoming.
- `examples/README.md` — added the three new examples to the table.
- `tsconfig.typedoc.json` — added the idempotency package path + include so typedoc API docs pick it up.

## Validation

- `pnpm install` — OK.
- `pnpm --filter "./packages/*" build` — all packages build.
- `pnpm typecheck` — all 15 projects pass, including the three new examples and the existing examples.
- The three new examples also build cleanly with `tsup`.
- `pnpm-lock.yaml` updated for the new example workspaces and committed.

## Assumptions

- **typedoc**: the root `tsconfig.typedoc.json` is configured with per-package `paths` + `include` entries, so I added `@kotodayori/idempotency` consistently in both places (minimal, consistent change). No per-package typedoc entry-point config exists beyond this.
- **Examples typecheck against the placeholder**: since the real API isn't implemented, each example imports `PACKAGE_NAME` from `@kotodayori/idempotency` (the only current export) and keeps the `idempotency()`/store wiring in clearly-labeled preview comments, so the workspace build/typecheck stays green until the package is implemented.
- **Language-switch convention**: the task referenced a language-switch line in `packages/core/README.md`; no such line currently exists in the repo, so I added the requested `**English** | [日本語](...)` style consistently to the new idempotency READMEs.

Closes #62


---
_Generated by [Claude Code](https://claude.ai/code/session_01UzKPSWgLnuuqbVNhgq7Ect)_