### PR TITLE
docs: add npm badges to site and package READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Kotodayori
 
+[![npm version](https://img.shields.io/npm/v/@kotodayori%2Fcore.svg?logo=npm&label=core)](https://www.npmjs.com/package/@kotodayori/core)
+[![npm version](https://img.shields.io/npm/v/@kotodayori%2Fstripe.svg?logo=npm&label=stripe)](https://www.npmjs.com/package/@kotodayori/stripe)
+[![npm downloads](https://img.shields.io/npm/dm/@kotodayori%2Fcore.svg)](https://www.npmjs.com/package/@kotodayori/core)
+[![license](https://img.shields.io/npm/l/@kotodayori%2Fcore.svg)](./LICENSE)
+
 A Hono-inspired, type-safe webhook routing library for TypeScript.
 
 ## Overview
@@ -17,13 +22,16 @@ Kotodayori provides a clean, type-safe API for handling webhooks from any event 
 
 ## Packages
 
-- `@kotodayori/core` - Core webhook routing logic and Verifier type
-- `@kotodayori/stripe` - Stripe-specific type definitions, router, and verifier
-- `@kotodayori/hono` - Hono framework adapter
-- `@kotodayori/express` - Express framework adapter
-- `@kotodayori/lambda` - AWS Lambda adapter
-- `@kotodayori/eventbridge` - AWS EventBridge adapter
-- `create-kotodayori` - Scaffolding tool for creating new projects
+| Package | npm | Description |
+|---------|-----|-------------|
+| [`@kotodayori/core`](./packages/core) | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fcore.svg)](https://www.npmjs.com/package/@kotodayori/core) | Core webhook routing logic and Verifier type |
+| [`@kotodayori/stripe`](./packages/stripe) | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fstripe.svg)](https://www.npmjs.com/package/@kotodayori/stripe) | Stripe-specific type definitions, router, and verifier |
+| [`@kotodayori/zod`](./packages/zod) | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fzod.svg)](https://www.npmjs.com/package/@kotodayori/zod) | Zod schema validation helpers |
+| [`@kotodayori/hono`](./packages/hono) | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fhono.svg)](https://www.npmjs.com/package/@kotodayori/hono) | Hono framework adapter |
+| [`@kotodayori/express`](./packages/express) | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fexpress.svg)](https://www.npmjs.com/package/@kotodayori/express) | Express framework adapter |
+| [`@kotodayori/lambda`](./packages/lambda) | [![npm](https://img.shields.io/npm/v/@kotodayori%2Flambda.svg)](https://www.npmjs.com/package/@kotodayori/lambda) | AWS Lambda adapter |
+| [`@kotodayori/eventbridge`](./packages/eventbridge) | [![npm](https://img.shields.io/npm/v/@kotodayori%2Feventbridge.svg)](https://www.npmjs.com/package/@kotodayori/eventbridge) | AWS EventBridge adapter |
+| [`create-kotodayori`](./packages/create-kotodayori) | [![npm](https://img.shields.io/npm/v/create-kotodayori.svg)](https://www.npmjs.com/package/create-kotodayori) | Scaffolding tool for creating new projects |
 
 ## Examples (monorepo)
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Kotodayori
 
-[![npm version](https://img.shields.io/npm/v/@kotodayori%2Fcore.svg?logo=npm&label=core)](https://www.npmjs.com/package/@kotodayori/core)
-[![npm version](https://img.shields.io/npm/v/@kotodayori%2Fstripe.svg?logo=npm&label=stripe)](https://www.npmjs.com/package/@kotodayori/stripe)
-[![npm downloads](https://img.shields.io/npm/dm/@kotodayori%2Fcore.svg)](https://www.npmjs.com/package/@kotodayori/core)
-[![license](https://img.shields.io/npm/l/@kotodayori%2Fcore.svg)](./LICENSE)
+[![npm version](https://img.shields.io/npm/v/%40kotodayori%2Fcore.svg?logo=npm&label=core)](https://www.npmjs.com/package/@kotodayori/core)
+[![npm version](https://img.shields.io/npm/v/%40kotodayori%2Fstripe.svg?logo=npm&label=stripe)](https://www.npmjs.com/package/@kotodayori/stripe)
+[![npm downloads](https://img.shields.io/npm/dm/%40kotodayori%2Fcore.svg)](https://www.npmjs.com/package/@kotodayori/core)
+[![license](https://img.shields.io/npm/l/%40kotodayori%2Fcore.svg)](./LICENSE)
 
 A Hono-inspired, type-safe webhook routing library for TypeScript.
 
@@ -24,13 +24,13 @@ Kotodayori provides a clean, type-safe API for handling webhooks from any event 
 
 | Package | npm | Description |
 |---------|-----|-------------|
-| [`@kotodayori/core`](./packages/core) | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fcore.svg)](https://www.npmjs.com/package/@kotodayori/core) | Core webhook routing logic and Verifier type |
-| [`@kotodayori/stripe`](./packages/stripe) | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fstripe.svg)](https://www.npmjs.com/package/@kotodayori/stripe) | Stripe-specific type definitions, router, and verifier |
-| [`@kotodayori/zod`](./packages/zod) | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fzod.svg)](https://www.npmjs.com/package/@kotodayori/zod) | Zod schema validation helpers |
-| [`@kotodayori/hono`](./packages/hono) | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fhono.svg)](https://www.npmjs.com/package/@kotodayori/hono) | Hono framework adapter |
-| [`@kotodayori/express`](./packages/express) | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fexpress.svg)](https://www.npmjs.com/package/@kotodayori/express) | Express framework adapter |
-| [`@kotodayori/lambda`](./packages/lambda) | [![npm](https://img.shields.io/npm/v/@kotodayori%2Flambda.svg)](https://www.npmjs.com/package/@kotodayori/lambda) | AWS Lambda adapter |
-| [`@kotodayori/eventbridge`](./packages/eventbridge) | [![npm](https://img.shields.io/npm/v/@kotodayori%2Feventbridge.svg)](https://www.npmjs.com/package/@kotodayori/eventbridge) | AWS EventBridge adapter |
+| [`@kotodayori/core`](./packages/core) | [![npm](https://img.shields.io/npm/v/%40kotodayori%2Fcore.svg)](https://www.npmjs.com/package/@kotodayori/core) | Core webhook routing logic and Verifier type |
+| [`@kotodayori/stripe`](./packages/stripe) | [![npm](https://img.shields.io/npm/v/%40kotodayori%2Fstripe.svg)](https://www.npmjs.com/package/@kotodayori/stripe) | Stripe-specific type definitions, router, and verifier |
+| [`@kotodayori/zod`](./packages/zod) | [![npm](https://img.shields.io/npm/v/%40kotodayori%2Fzod.svg)](https://www.npmjs.com/package/@kotodayori/zod) | Zod schema validation helpers |
+| [`@kotodayori/hono`](./packages/hono) | [![npm](https://img.shields.io/npm/v/%40kotodayori%2Fhono.svg)](https://www.npmjs.com/package/@kotodayori/hono) | Hono framework adapter |
+| [`@kotodayori/express`](./packages/express) | [![npm](https://img.shields.io/npm/v/%40kotodayori%2Fexpress.svg)](https://www.npmjs.com/package/@kotodayori/express) | Express framework adapter |
+| [`@kotodayori/lambda`](./packages/lambda) | [![npm](https://img.shields.io/npm/v/%40kotodayori%2Flambda.svg)](https://www.npmjs.com/package/@kotodayori/lambda) | AWS Lambda adapter |
+| [`@kotodayori/eventbridge`](./packages/eventbridge) | [![npm](https://img.shields.io/npm/v/%40kotodayori%2Feventbridge.svg)](https://www.npmjs.com/package/@kotodayori/eventbridge) | AWS EventBridge adapter |
 | [`create-kotodayori`](./packages/create-kotodayori) | [![npm](https://img.shields.io/npm/v/create-kotodayori.svg)](https://www.npmjs.com/package/create-kotodayori) | Scaffolding tool for creating new projects |
 
 ## Examples (monorepo)

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -63,11 +63,11 @@ export default app;
 
 | Package | npm | Description |
 |---------|-----|-------------|
-| `@kotodayori/core` | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fcore.svg)](https://www.npmjs.com/package/@kotodayori/core) | Core webhook routing logic and Verifier type |
-| `@kotodayori/stripe` | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fstripe.svg)](https://www.npmjs.com/package/@kotodayori/stripe) | Stripe-specific types, router, and verifier |
-| `@kotodayori/zod` | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fzod.svg)](https://www.npmjs.com/package/@kotodayori/zod) | Zod schema validation helpers |
-| `@kotodayori/hono` | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fhono.svg)](https://www.npmjs.com/package/@kotodayori/hono) | Hono framework adapter |
-| `@kotodayori/express` | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fexpress.svg)](https://www.npmjs.com/package/@kotodayori/express) | Express framework adapter |
-| `@kotodayori/lambda` | [![npm](https://img.shields.io/npm/v/@kotodayori%2Flambda.svg)](https://www.npmjs.com/package/@kotodayori/lambda) | AWS Lambda adapter |
-| `@kotodayori/eventbridge` | [![npm](https://img.shields.io/npm/v/@kotodayori%2Feventbridge.svg)](https://www.npmjs.com/package/@kotodayori/eventbridge) | AWS EventBridge adapter |
+| `@kotodayori/core` | [![npm](https://img.shields.io/npm/v/%40kotodayori%2Fcore.svg)](https://www.npmjs.com/package/@kotodayori/core) | Core webhook routing logic and Verifier type |
+| `@kotodayori/stripe` | [![npm](https://img.shields.io/npm/v/%40kotodayori%2Fstripe.svg)](https://www.npmjs.com/package/@kotodayori/stripe) | Stripe-specific types, router, and verifier |
+| `@kotodayori/zod` | [![npm](https://img.shields.io/npm/v/%40kotodayori%2Fzod.svg)](https://www.npmjs.com/package/@kotodayori/zod) | Zod schema validation helpers |
+| `@kotodayori/hono` | [![npm](https://img.shields.io/npm/v/%40kotodayori%2Fhono.svg)](https://www.npmjs.com/package/@kotodayori/hono) | Hono framework adapter |
+| `@kotodayori/express` | [![npm](https://img.shields.io/npm/v/%40kotodayori%2Fexpress.svg)](https://www.npmjs.com/package/@kotodayori/express) | Express framework adapter |
+| `@kotodayori/lambda` | [![npm](https://img.shields.io/npm/v/%40kotodayori%2Flambda.svg)](https://www.npmjs.com/package/@kotodayori/lambda) | AWS Lambda adapter |
+| `@kotodayori/eventbridge` | [![npm](https://img.shields.io/npm/v/%40kotodayori%2Feventbridge.svg)](https://www.npmjs.com/package/@kotodayori/eventbridge) | AWS EventBridge adapter |
 | `create-kotodayori` | [![npm](https://img.shields.io/npm/v/create-kotodayori.svg)](https://www.npmjs.com/package/create-kotodayori) | Scaffolding tool for new projects |

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -61,13 +61,13 @@ export default app;
 
 ## Packages
 
-| Package | Description |
-|---------|-------------|
-| `@kotodayori/core` | Core webhook routing logic and Verifier type |
-| `@kotodayori/stripe` | Stripe-specific types, router, and verifier |
-| `@kotodayori/zod` | Zod schema validation helpers |
-| `@kotodayori/hono` | Hono framework adapter |
-| `@kotodayori/express` | Express framework adapter |
-| `@kotodayori/lambda` | AWS Lambda adapter |
-| `@kotodayori/eventbridge` | AWS EventBridge adapter |
-| `create-kotodayori` | Scaffolding tool for new projects |
+| Package | npm | Description |
+|---------|-----|-------------|
+| `@kotodayori/core` | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fcore.svg)](https://www.npmjs.com/package/@kotodayori/core) | Core webhook routing logic and Verifier type |
+| `@kotodayori/stripe` | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fstripe.svg)](https://www.npmjs.com/package/@kotodayori/stripe) | Stripe-specific types, router, and verifier |
+| `@kotodayori/zod` | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fzod.svg)](https://www.npmjs.com/package/@kotodayori/zod) | Zod schema validation helpers |
+| `@kotodayori/hono` | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fhono.svg)](https://www.npmjs.com/package/@kotodayori/hono) | Hono framework adapter |
+| `@kotodayori/express` | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fexpress.svg)](https://www.npmjs.com/package/@kotodayori/express) | Express framework adapter |
+| `@kotodayori/lambda` | [![npm](https://img.shields.io/npm/v/@kotodayori%2Flambda.svg)](https://www.npmjs.com/package/@kotodayori/lambda) | AWS Lambda adapter |
+| `@kotodayori/eventbridge` | [![npm](https://img.shields.io/npm/v/@kotodayori%2Feventbridge.svg)](https://www.npmjs.com/package/@kotodayori/eventbridge) | AWS EventBridge adapter |
+| `create-kotodayori` | [![npm](https://img.shields.io/npm/v/create-kotodayori.svg)](https://www.npmjs.com/package/create-kotodayori) | Scaffolding tool for new projects |

--- a/docs/src/content/docs/ja/index.mdx
+++ b/docs/src/content/docs/ja/index.mdx
@@ -61,13 +61,13 @@ export default app;
 
 ## パッケージ
 
-| パッケージ | 説明 |
-|---------|-------------|
-| `@kotodayori/core` | Webhook ルーティングのコアロジックと Verifier 型 |
-| `@kotodayori/stripe` | Stripe 固有の型・ルーター・Verifier |
-| `@kotodayori/zod` | Zod スキーマバリデーションヘルパー |
-| `@kotodayori/hono` | Hono フレームワークアダプター |
-| `@kotodayori/express` | Express フレームワークアダプター |
-| `@kotodayori/lambda` | AWS Lambda アダプター |
-| `@kotodayori/eventbridge` | AWS EventBridge アダプター |
-| `create-kotodayori` | 新規プロジェクト用スキャフォールディングツール |
+| パッケージ | npm | 説明 |
+|---------|-----|-------------|
+| `@kotodayori/core` | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fcore.svg)](https://www.npmjs.com/package/@kotodayori/core) | Webhook ルーティングのコアロジックと Verifier 型 |
+| `@kotodayori/stripe` | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fstripe.svg)](https://www.npmjs.com/package/@kotodayori/stripe) | Stripe 固有の型・ルーター・Verifier |
+| `@kotodayori/zod` | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fzod.svg)](https://www.npmjs.com/package/@kotodayori/zod) | Zod スキーマバリデーションヘルパー |
+| `@kotodayori/hono` | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fhono.svg)](https://www.npmjs.com/package/@kotodayori/hono) | Hono フレームワークアダプター |
+| `@kotodayori/express` | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fexpress.svg)](https://www.npmjs.com/package/@kotodayori/express) | Express フレームワークアダプター |
+| `@kotodayori/lambda` | [![npm](https://img.shields.io/npm/v/@kotodayori%2Flambda.svg)](https://www.npmjs.com/package/@kotodayori/lambda) | AWS Lambda アダプター |
+| `@kotodayori/eventbridge` | [![npm](https://img.shields.io/npm/v/@kotodayori%2Feventbridge.svg)](https://www.npmjs.com/package/@kotodayori/eventbridge) | AWS EventBridge アダプター |
+| `create-kotodayori` | [![npm](https://img.shields.io/npm/v/create-kotodayori.svg)](https://www.npmjs.com/package/create-kotodayori) | 新規プロジェクト用スキャフォールディングツール |

--- a/docs/src/content/docs/ja/index.mdx
+++ b/docs/src/content/docs/ja/index.mdx
@@ -63,11 +63,11 @@ export default app;
 
 | パッケージ | npm | 説明 |
 |---------|-----|-------------|
-| `@kotodayori/core` | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fcore.svg)](https://www.npmjs.com/package/@kotodayori/core) | Webhook ルーティングのコアロジックと Verifier 型 |
-| `@kotodayori/stripe` | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fstripe.svg)](https://www.npmjs.com/package/@kotodayori/stripe) | Stripe 固有の型・ルーター・Verifier |
-| `@kotodayori/zod` | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fzod.svg)](https://www.npmjs.com/package/@kotodayori/zod) | Zod スキーマバリデーションヘルパー |
-| `@kotodayori/hono` | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fhono.svg)](https://www.npmjs.com/package/@kotodayori/hono) | Hono フレームワークアダプター |
-| `@kotodayori/express` | [![npm](https://img.shields.io/npm/v/@kotodayori%2Fexpress.svg)](https://www.npmjs.com/package/@kotodayori/express) | Express フレームワークアダプター |
-| `@kotodayori/lambda` | [![npm](https://img.shields.io/npm/v/@kotodayori%2Flambda.svg)](https://www.npmjs.com/package/@kotodayori/lambda) | AWS Lambda アダプター |
-| `@kotodayori/eventbridge` | [![npm](https://img.shields.io/npm/v/@kotodayori%2Feventbridge.svg)](https://www.npmjs.com/package/@kotodayori/eventbridge) | AWS EventBridge アダプター |
+| `@kotodayori/core` | [![npm](https://img.shields.io/npm/v/%40kotodayori%2Fcore.svg)](https://www.npmjs.com/package/@kotodayori/core) | Webhook ルーティングのコアロジックと Verifier 型 |
+| `@kotodayori/stripe` | [![npm](https://img.shields.io/npm/v/%40kotodayori%2Fstripe.svg)](https://www.npmjs.com/package/@kotodayori/stripe) | Stripe 固有の型・ルーター・Verifier |
+| `@kotodayori/zod` | [![npm](https://img.shields.io/npm/v/%40kotodayori%2Fzod.svg)](https://www.npmjs.com/package/@kotodayori/zod) | Zod スキーマバリデーションヘルパー |
+| `@kotodayori/hono` | [![npm](https://img.shields.io/npm/v/%40kotodayori%2Fhono.svg)](https://www.npmjs.com/package/@kotodayori/hono) | Hono フレームワークアダプター |
+| `@kotodayori/express` | [![npm](https://img.shields.io/npm/v/%40kotodayori%2Fexpress.svg)](https://www.npmjs.com/package/@kotodayori/express) | Express フレームワークアダプター |
+| `@kotodayori/lambda` | [![npm](https://img.shields.io/npm/v/%40kotodayori%2Flambda.svg)](https://www.npmjs.com/package/@kotodayori/lambda) | AWS Lambda アダプター |
+| `@kotodayori/eventbridge` | [![npm](https://img.shields.io/npm/v/%40kotodayori%2Feventbridge.svg)](https://www.npmjs.com/package/@kotodayori/eventbridge) | AWS EventBridge アダプター |
 | `create-kotodayori` | [![npm](https://img.shields.io/npm/v/create-kotodayori.svg)](https://www.npmjs.com/package/create-kotodayori) | 新規プロジェクト用スキャフォールディングツール |

--- a/docs/src/content/docs/ja/packages/core.md
+++ b/docs/src/content/docs/ja/packages/core.md
@@ -3,6 +3,10 @@ title: "@kotodayori/core"
 description: フレームワーク非依存の Webhook ルーティングエンジン
 ---
 
+[![npm version](https://img.shields.io/npm/v/%40kotodayori%2Fcore.svg?logo=npm&label=npm)](https://www.npmjs.com/package/@kotodayori/core)
+[![npm downloads](https://img.shields.io/npm/dm/%40kotodayori%2Fcore.svg)](https://www.npmjs.com/package/@kotodayori/core)
+[![license](https://img.shields.io/npm/l/%40kotodayori%2Fcore.svg)](https://www.npmjs.com/package/@kotodayori/core)
+
 コアパッケージは、フレームワーク依存ゼロの Webhook ルーティングエンジンを提供します。すべてのアダプター（Hono・Express・Lambda・EventBridge）はこのパッケージの上に構築されています。
 
 ## インストール

--- a/docs/src/content/docs/ja/packages/create-kotodayori.md
+++ b/docs/src/content/docs/ja/packages/create-kotodayori.md
@@ -3,6 +3,10 @@ title: create-kotodayori
 description: 新規 Kotodayori プロジェクト用スキャフォールディングツール
 ---
 
+[![npm version](https://img.shields.io/npm/v/create-kotodayori.svg?logo=npm&label=npm)](https://www.npmjs.com/package/create-kotodayori)
+[![npm downloads](https://img.shields.io/npm/dm/create-kotodayori.svg)](https://www.npmjs.com/package/create-kotodayori)
+[![license](https://img.shields.io/npm/l/create-kotodayori.svg)](https://www.npmjs.com/package/create-kotodayori)
+
 `create-kotodayori` は、選択したフレームワークとパッケージマネージャーで新規 Kotodayori プロジェクトをスキャフォールドする CLI ツールです。
 
 ## 使い方

--- a/docs/src/content/docs/ja/packages/eventbridge.md
+++ b/docs/src/content/docs/ja/packages/eventbridge.md
@@ -3,6 +3,10 @@ title: "@kotodayori/eventbridge"
 description: Kotodayori の AWS EventBridge アダプター
 ---
 
+[![npm version](https://img.shields.io/npm/v/%40kotodayori%2Feventbridge.svg?logo=npm&label=npm)](https://www.npmjs.com/package/@kotodayori/eventbridge)
+[![npm downloads](https://img.shields.io/npm/dm/%40kotodayori%2Feventbridge.svg)](https://www.npmjs.com/package/@kotodayori/eventbridge)
+[![license](https://img.shields.io/npm/l/%40kotodayori%2Feventbridge.svg)](https://www.npmjs.com/package/@kotodayori/eventbridge)
+
 EventBridge アダプターは、AWS EventBridge イベントによって呼び出されたときに Kotodayori ルーターを実行します。EventBridge はお客様の AWS アカウント内からイベントを配信するため、署名検証は不要です。
 
 ## インストール

--- a/docs/src/content/docs/ja/packages/express.md
+++ b/docs/src/content/docs/ja/packages/express.md
@@ -3,6 +3,10 @@ title: "@kotodayori/express"
 description: Kotodayori の Express フレームワークアダプター
 ---
 
+[![npm version](https://img.shields.io/npm/v/%40kotodayori%2Fexpress.svg?logo=npm&label=npm)](https://www.npmjs.com/package/@kotodayori/express)
+[![npm downloads](https://img.shields.io/npm/dm/%40kotodayori%2Fexpress.svg)](https://www.npmjs.com/package/@kotodayori/express)
+[![license](https://img.shields.io/npm/l/%40kotodayori%2Fexpress.svg)](https://www.npmjs.com/package/@kotodayori/express)
+
 Express アダプターは、Kotodayori ルーターを Express アプリに接続します。署名検証のために生のリクエストボディを提供する必要があります。
 
 ## インストール

--- a/docs/src/content/docs/ja/packages/hono.md
+++ b/docs/src/content/docs/ja/packages/hono.md
@@ -3,6 +3,10 @@ title: "@kotodayori/hono"
 description: Kotodayori の Hono フレームワークアダプター
 ---
 
+[![npm version](https://img.shields.io/npm/v/%40kotodayori%2Fhono.svg?logo=npm&label=npm)](https://www.npmjs.com/package/@kotodayori/hono)
+[![npm downloads](https://img.shields.io/npm/dm/%40kotodayori%2Fhono.svg)](https://www.npmjs.com/package/@kotodayori/hono)
+[![license](https://img.shields.io/npm/l/%40kotodayori%2Fhono.svg)](https://www.npmjs.com/package/@kotodayori/hono)
+
 Hono アダプターは、Kotodayori ルーターを Hono アプリに接続し、生のリクエストボディの取得・署名検証・レスポンス生成を処理します。
 
 ## インストール

--- a/docs/src/content/docs/ja/packages/lambda.md
+++ b/docs/src/content/docs/ja/packages/lambda.md
@@ -3,6 +3,10 @@ title: "@kotodayori/lambda"
 description: Kotodayori の AWS Lambda（API Gateway）アダプター
 ---
 
+[![npm version](https://img.shields.io/npm/v/%40kotodayori%2Flambda.svg?logo=npm&label=npm)](https://www.npmjs.com/package/@kotodayori/lambda)
+[![npm downloads](https://img.shields.io/npm/dm/%40kotodayori%2Flambda.svg)](https://www.npmjs.com/package/@kotodayori/lambda)
+[![license](https://img.shields.io/npm/l/%40kotodayori%2Flambda.svg)](https://www.npmjs.com/package/@kotodayori/lambda)
+
 Lambda アダプターは、API Gateway HTTP イベント（例: API Gateway 経由の Webhook エンドポイント）に応答して Kotodayori ルーターを実行します。
 
 ## インストール

--- a/docs/src/content/docs/ja/packages/stripe.md
+++ b/docs/src/content/docs/ja/packages/stripe.md
@@ -3,6 +3,10 @@ title: "@kotodayori/stripe"
 description: Stripe 固有の型・ルーター・Verifier
 ---
 
+[![npm version](https://img.shields.io/npm/v/%40kotodayori%2Fstripe.svg?logo=npm&label=npm)](https://www.npmjs.com/package/@kotodayori/stripe)
+[![npm downloads](https://img.shields.io/npm/dm/%40kotodayori%2Fstripe.svg)](https://www.npmjs.com/package/@kotodayori/stripe)
+[![license](https://img.shields.io/npm/l/%40kotodayori%2Fstripe.svg)](https://www.npmjs.com/package/@kotodayori/stripe)
+
 Stripe パッケージは、コアルーターを Stripe 固有の型で拡張し、Stripe Webhook の署名検証機能を提供します。
 
 ## インストール

--- a/docs/src/content/docs/ja/packages/zod.md
+++ b/docs/src/content/docs/ja/packages/zod.md
@@ -3,6 +3,10 @@ title: "@kotodayori/zod"
 description: ランタイムバリデーション用の Zod スキーマヘルパー
 ---
 
+[![npm version](https://img.shields.io/npm/v/%40kotodayori%2Fzod.svg?logo=npm&label=npm)](https://www.npmjs.com/package/@kotodayori/zod)
+[![npm downloads](https://img.shields.io/npm/dm/%40kotodayori%2Fzod.svg)](https://www.npmjs.com/package/@kotodayori/zod)
+[![license](https://img.shields.io/npm/l/%40kotodayori%2Fzod.svg)](https://www.npmjs.com/package/@kotodayori/zod)
+
 Zod パッケージは、Kotodayori の型安全なルーティングにランタイムスキーマ検証を追加します。外部または信頼性の低いソースからの Webhook ペイロードをランタイムで検証する必要がある場合に使用してください。
 
 ## インストール

--- a/docs/src/content/docs/packages/core.md
+++ b/docs/src/content/docs/packages/core.md
@@ -3,6 +3,10 @@ title: "@kotodayori/core"
 description: Framework-agnostic webhook routing engine
 ---
 
+[![npm version](https://img.shields.io/npm/v/%40kotodayori%2Fcore.svg?logo=npm&label=npm)](https://www.npmjs.com/package/@kotodayori/core)
+[![npm downloads](https://img.shields.io/npm/dm/%40kotodayori%2Fcore.svg)](https://www.npmjs.com/package/@kotodayori/core)
+[![license](https://img.shields.io/npm/l/%40kotodayori%2Fcore.svg)](https://www.npmjs.com/package/@kotodayori/core)
+
 The core package provides the webhook routing engine with no framework dependencies. All adapters (Hono, Express, Lambda, EventBridge) build on top of it.
 
 ## Installation

--- a/docs/src/content/docs/packages/create-kotodayori.md
+++ b/docs/src/content/docs/packages/create-kotodayori.md
@@ -3,6 +3,10 @@ title: create-kotodayori
 description: Scaffolding tool for new Kotodayori projects
 ---
 
+[![npm version](https://img.shields.io/npm/v/create-kotodayori.svg?logo=npm&label=npm)](https://www.npmjs.com/package/create-kotodayori)
+[![npm downloads](https://img.shields.io/npm/dm/create-kotodayori.svg)](https://www.npmjs.com/package/create-kotodayori)
+[![license](https://img.shields.io/npm/l/create-kotodayori.svg)](https://www.npmjs.com/package/create-kotodayori)
+
 `create-kotodayori` is a CLI that scaffolds a new Kotodayori project with your chosen framework and package manager.
 
 ## Usage

--- a/docs/src/content/docs/packages/eventbridge.md
+++ b/docs/src/content/docs/packages/eventbridge.md
@@ -3,6 +3,10 @@ title: "@kotodayori/eventbridge"
 description: AWS EventBridge adapter for Kotodayori
 ---
 
+[![npm version](https://img.shields.io/npm/v/%40kotodayori%2Feventbridge.svg?logo=npm&label=npm)](https://www.npmjs.com/package/@kotodayori/eventbridge)
+[![npm downloads](https://img.shields.io/npm/dm/%40kotodayori%2Feventbridge.svg)](https://www.npmjs.com/package/@kotodayori/eventbridge)
+[![license](https://img.shields.io/npm/l/%40kotodayori%2Feventbridge.svg)](https://www.npmjs.com/package/@kotodayori/eventbridge)
+
 The EventBridge adapter runs a Kotodayori router when invoked by an AWS EventBridge event. Because EventBridge delivers events from within your AWS account, no signature verification is required.
 
 ## Installation

--- a/docs/src/content/docs/packages/express.md
+++ b/docs/src/content/docs/packages/express.md
@@ -3,6 +3,10 @@ title: "@kotodayori/express"
 description: Express framework adapter for Kotodayori
 ---
 
+[![npm version](https://img.shields.io/npm/v/%40kotodayori%2Fexpress.svg?logo=npm&label=npm)](https://www.npmjs.com/package/@kotodayori/express)
+[![npm downloads](https://img.shields.io/npm/dm/%40kotodayori%2Fexpress.svg)](https://www.npmjs.com/package/@kotodayori/express)
+[![license](https://img.shields.io/npm/l/%40kotodayori%2Fexpress.svg)](https://www.npmjs.com/package/@kotodayori/express)
+
 The Express adapter connects a Kotodayori router to an Express app. You must provide the raw request body for signature verification.
 
 ## Installation

--- a/docs/src/content/docs/packages/hono.md
+++ b/docs/src/content/docs/packages/hono.md
@@ -3,6 +3,10 @@ title: "@kotodayori/hono"
 description: Hono framework adapter for Kotodayori
 ---
 
+[![npm version](https://img.shields.io/npm/v/%40kotodayori%2Fhono.svg?logo=npm&label=npm)](https://www.npmjs.com/package/@kotodayori/hono)
+[![npm downloads](https://img.shields.io/npm/dm/%40kotodayori%2Fhono.svg)](https://www.npmjs.com/package/@kotodayori/hono)
+[![license](https://img.shields.io/npm/l/%40kotodayori%2Fhono.svg)](https://www.npmjs.com/package/@kotodayori/hono)
+
 The Hono adapter connects a Kotodayori router to a Hono app, handling raw body extraction, signature verification, and response formatting.
 
 ## Installation

--- a/docs/src/content/docs/packages/lambda.md
+++ b/docs/src/content/docs/packages/lambda.md
@@ -3,6 +3,10 @@ title: "@kotodayori/lambda"
 description: AWS Lambda (API Gateway) adapter for Kotodayori
 ---
 
+[![npm version](https://img.shields.io/npm/v/%40kotodayori%2Flambda.svg?logo=npm&label=npm)](https://www.npmjs.com/package/@kotodayori/lambda)
+[![npm downloads](https://img.shields.io/npm/dm/%40kotodayori%2Flambda.svg)](https://www.npmjs.com/package/@kotodayori/lambda)
+[![license](https://img.shields.io/npm/l/%40kotodayori%2Flambda.svg)](https://www.npmjs.com/package/@kotodayori/lambda)
+
 The Lambda adapter runs a Kotodayori router in response to API Gateway HTTP events (e.g. webhook endpoints behind API Gateway).
 
 ## Installation

--- a/docs/src/content/docs/packages/stripe.md
+++ b/docs/src/content/docs/packages/stripe.md
@@ -3,6 +3,10 @@ title: "@kotodayori/stripe"
 description: Stripe-specific types, router, and verifier
 ---
 
+[![npm version](https://img.shields.io/npm/v/%40kotodayori%2Fstripe.svg?logo=npm&label=npm)](https://www.npmjs.com/package/@kotodayori/stripe)
+[![npm downloads](https://img.shields.io/npm/dm/%40kotodayori%2Fstripe.svg)](https://www.npmjs.com/package/@kotodayori/stripe)
+[![license](https://img.shields.io/npm/l/%40kotodayori%2Fstripe.svg)](https://www.npmjs.com/package/@kotodayori/stripe)
+
 The Stripe package extends the core router with Stripe-specific types and provides a signature verifier for Stripe webhooks.
 
 ## Installation

--- a/docs/src/content/docs/packages/zod.md
+++ b/docs/src/content/docs/packages/zod.md
@@ -3,6 +3,10 @@ title: "@kotodayori/zod"
 description: Zod schema validation helpers for runtime validation
 ---
 
+[![npm version](https://img.shields.io/npm/v/%40kotodayori%2Fzod.svg?logo=npm&label=npm)](https://www.npmjs.com/package/@kotodayori/zod)
+[![npm downloads](https://img.shields.io/npm/dm/%40kotodayori%2Fzod.svg)](https://www.npmjs.com/package/@kotodayori/zod)
+[![license](https://img.shields.io/npm/l/%40kotodayori%2Fzod.svg)](https://www.npmjs.com/package/@kotodayori/zod)
+
 The Zod package adds runtime schema validation on top of Kotodayori’s type-safe routing. Use it when you need to validate webhook payloads at runtime (e.g. for external or less trusted sources).
 
 ## Installation

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,5 +1,9 @@
 # @kotodayori/core
 
+[![npm version](https://img.shields.io/npm/v/%40kotodayori%2Fcore.svg?logo=npm&label=npm)](https://www.npmjs.com/package/@kotodayori/core)
+[![npm downloads](https://img.shields.io/npm/dm/%40kotodayori%2Fcore.svg)](https://www.npmjs.com/package/@kotodayori/core)
+[![license](https://img.shields.io/npm/l/%40kotodayori%2Fcore.svg)](https://www.npmjs.com/package/@kotodayori/core)
+
 Type-safe webhook routing framework for any event source.
 
 ## Overview

--- a/packages/create-kotodayori/README.md
+++ b/packages/create-kotodayori/README.md
@@ -1,5 +1,9 @@
 # create-kotodayori
 
+[![npm version](https://img.shields.io/npm/v/create-kotodayori.svg?logo=npm&label=npm)](https://www.npmjs.com/package/create-kotodayori)
+[![npm downloads](https://img.shields.io/npm/dm/create-kotodayori.svg)](https://www.npmjs.com/package/create-kotodayori)
+[![license](https://img.shields.io/npm/l/create-kotodayori.svg)](https://www.npmjs.com/package/create-kotodayori)
+
 Scaffolding tool for creating Kotodayori webhook handler projects.
 
 ## Usage

--- a/packages/eventbridge/README.md
+++ b/packages/eventbridge/README.md
@@ -1,5 +1,9 @@
 # @kotodayori/eventbridge
 
+[![npm version](https://img.shields.io/npm/v/%40kotodayori%2Feventbridge.svg?logo=npm&label=npm)](https://www.npmjs.com/package/@kotodayori/eventbridge)
+[![npm downloads](https://img.shields.io/npm/dm/%40kotodayori%2Feventbridge.svg)](https://www.npmjs.com/package/@kotodayori/eventbridge)
+[![license](https://img.shields.io/npm/l/%40kotodayori%2Feventbridge.svg)](https://www.npmjs.com/package/@kotodayori/eventbridge)
+
 AWS EventBridge adapter for Kotodayori webhook router.
 
 ## Overview

--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -1,5 +1,9 @@
 # @kotodayori/express
 
+[![npm version](https://img.shields.io/npm/v/%40kotodayori%2Fexpress.svg?logo=npm&label=npm)](https://www.npmjs.com/package/@kotodayori/express)
+[![npm downloads](https://img.shields.io/npm/dm/%40kotodayori%2Fexpress.svg)](https://www.npmjs.com/package/@kotodayori/express)
+[![license](https://img.shields.io/npm/l/%40kotodayori%2Fexpress.svg)](https://www.npmjs.com/package/@kotodayori/express)
+
 Express framework adapter for Kotodayori webhook router.
 
 ## Overview

--- a/packages/hono/README.md
+++ b/packages/hono/README.md
@@ -1,5 +1,9 @@
 # @kotodayori/hono
 
+[![npm version](https://img.shields.io/npm/v/%40kotodayori%2Fhono.svg?logo=npm&label=npm)](https://www.npmjs.com/package/@kotodayori/hono)
+[![npm downloads](https://img.shields.io/npm/dm/%40kotodayori%2Fhono.svg)](https://www.npmjs.com/package/@kotodayori/hono)
+[![license](https://img.shields.io/npm/l/%40kotodayori%2Fhono.svg)](https://www.npmjs.com/package/@kotodayori/hono)
+
 Hono framework adapter for Kotodayori webhook router.
 
 ## Overview

--- a/packages/lambda/README.md
+++ b/packages/lambda/README.md
@@ -1,5 +1,9 @@
 # @kotodayori/lambda
 
+[![npm version](https://img.shields.io/npm/v/%40kotodayori%2Flambda.svg?logo=npm&label=npm)](https://www.npmjs.com/package/@kotodayori/lambda)
+[![npm downloads](https://img.shields.io/npm/dm/%40kotodayori%2Flambda.svg)](https://www.npmjs.com/package/@kotodayori/lambda)
+[![license](https://img.shields.io/npm/l/%40kotodayori%2Flambda.svg)](https://www.npmjs.com/package/@kotodayori/lambda)
+
 AWS Lambda adapter for Kotodayori webhook router.
 
 ## Overview

--- a/packages/stripe/README.md
+++ b/packages/stripe/README.md
@@ -1,5 +1,9 @@
 # @kotodayori/stripe
 
+[![npm version](https://img.shields.io/npm/v/%40kotodayori%2Fstripe.svg?logo=npm&label=npm)](https://www.npmjs.com/package/@kotodayori/stripe)
+[![npm downloads](https://img.shields.io/npm/dm/%40kotodayori%2Fstripe.svg)](https://www.npmjs.com/package/@kotodayori/stripe)
+[![license](https://img.shields.io/npm/l/%40kotodayori%2Fstripe.svg)](https://www.npmjs.com/package/@kotodayori/stripe)
+
 Stripe-specific type definitions, router, and webhook verifier for Kotodayori.
 
 ## Overview

--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -1,5 +1,9 @@
 # @kotodayori/zod
 
+[![npm version](https://img.shields.io/npm/v/%40kotodayori%2Fzod.svg?logo=npm&label=npm)](https://www.npmjs.com/package/@kotodayori/zod)
+[![npm downloads](https://img.shields.io/npm/dm/%40kotodayori%2Fzod.svg)](https://www.npmjs.com/package/@kotodayori/zod)
+[![license](https://img.shields.io/npm/l/%40kotodayori%2Fzod.svg)](https://www.npmjs.com/package/@kotodayori/zod)
+
 Zod schema validation helpers for Kotodayori webhook router.
 
 ## Overview


### PR DESCRIPTION
Add npm version/downloads/license badges to each package README, the
docs site package pages (en + ja), and npm links in the package tables
of the root README and docs index pages. Also add the missing
@kotodayori/zod entry to the root README package list.