### PR TITLE
docs(stripe): adopt Dependabot-driven event map drift policy (redo of #82)

### DIFF
--- a/packages/stripe/MAINTAINING_STRIPE_EVENTMAP.md
+++ b/packages/stripe/MAINTAINING_STRIPE_EVENTMAP.md
@@ -44,7 +44,7 @@ export type StripeEventMap = {
 The event map is only ever derived from the **installed** `stripe` SDK. The
 check script (`scripts/check-events.ts`) reads
 `node_modules/stripe/cjs/resources/Events.d.ts` from the pinned SDK and diffs
-it against `StripeEventMap`. The version is fixed in two places:
+it against `StripeEventMap`. The version is specified in two places:
 
 - **devDependency `stripe: ^22.0.0`** — the version actually installed and used
   to generate/verify the event map. It is locked in `pnpm-lock.yaml`, so a

--- a/packages/stripe/MAINTAINING_STRIPE_EVENTMAP.md
+++ b/packages/stripe/MAINTAINING_STRIPE_EVENTMAP.md
@@ -39,23 +39,79 @@ export type StripeEventMap = {
 4. Run `pnpm run check-events` to verify
 5. Run `pnpm test` to ensure types compile correctly
 
-## Stripe SDK Updates
+## Stripe SDK version pinning policy
 
-When updating the `stripe` package:
+The event map is only ever derived from the **installed** `stripe` SDK. The
+check script (`scripts/check-events.ts`) reads
+`node_modules/stripe/cjs/resources/Events.d.ts` from the pinned SDK and diffs
+it against `StripeEventMap`. The version is fixed in two places:
 
-1. Update the dependency: `pnpm update stripe`
-2. Run `pnpm run check-events` to detect any new events
-3. Add any missing events to `StripeEventMap`
-4. Run the test suite: `pnpm test`
+- **devDependency `stripe: ^22.0.0`** — the version actually installed and used
+  to generate/verify the event map. It is locked in `pnpm-lock.yaml`, so a
+  frozen install always resolves to the same SDK build.
+- **peerDependency `stripe: >=17.0.0`** — the range consumers of
+  `@kotodayori/stripe` may bring. We intentionally support older Stripe majors
+  here; the event map is a superset that remains type-compatible.
 
-## CI Integration
+Because the installed SDK is pinned and lockfile-frozen, **the event map can
+only drift when the `stripe` dependency is bumped.** Re-running the check on the
+same pinned version always returns the same result, so there is nothing new to
+detect between bumps.
 
-Consider adding the check script to your CI pipeline:
+### Bumping `stripe`
+
+Bumps are performed **through Dependabot** (`.github/dependabot.yml`, weekly
+`npm` updates on directory `/`, which covers this package). When a Dependabot PR
+raises `stripe`:
+
+1. The existing `check-stripe-events` CI job (see below) runs automatically on
+   that PR and surfaces any new/removed events.
+2. If it fails, update `StripeEventMap` in `src/index.ts` to match, then run
+   `pnpm test` to confirm types compile.
+3. Do not merge until `pnpm run check-events` is green ("in sync").
+
+Manual bumps follow the same flow: `pnpm update stripe` → `pnpm run check-events`
+→ reconcile the map → `pnpm test`.
+
+## CI Integration (adopted policy)
+
+Drift detection is wired into the regular CI pipeline as a **blocking check with
+no write permissions** — there is no scheduled run and no automatic issue
+creation. This is the deliberate, final policy (it supersedes the earlier
+"consider adding it to CI" suggestion and replaces the approach proposed in the
+now-closed PR #82).
+
+**`check-stripe-events` job (`.github/workflows/ci.yml`, "case A")**
 
 ```yaml
-# .github/workflows/ci.yml
-- name: Check Stripe events sync
-  run: pnpm run check-events
+check-stripe-events:
+  name: Check Stripe Events Sync
+  runs-on: ubuntu-latest
+  steps:
+    # checkout, pnpm, Node, frozen install …
+    - name: Check Stripe Event Map sync
+      run: pnpm --filter @kotodayori/stripe run check-events
 ```
 
-This will fail the build if the event map becomes out of sync with the SDK.
+- Runs on every `push`/`pull_request` to `main`/`develop`.
+- Requires **no permissions** — it only reads the repo and fails the build on
+  drift. Nothing is written back to GitHub.
+- It fires at exactly the right moment: on the **Dependabot PR that bumps
+  `stripe`**, which is the only event that can actually move the event map.
+
+### Why no scheduled run or auto-issue?
+
+A weekly scheduled job that does a frozen install would re-check the *same*
+pinned SDK every time, so it can never detect anything new — drift is gated on a
+dependency bump, and bumps already arrive as Dependabot PRs where case A runs.
+Adding `issues: write` (or any write scope) to an OSS CI workflow also widens
+the supply-chain attack surface for no real signal. We therefore deliberately
+omit a scheduled job and any automated issue/PR creation; the Dependabot-driven
+case A check is sufficient and keeps CI permission-free.
+
+An optional **read-only** scheduled job that installs `stripe@latest` (ahead of
+the pin) and prints the diff to `$GITHUB_STEP_SUMMARY` was considered for early
+warning, but skipped: Dependabot already runs weekly, so the lead time gained is
+marginal, and it would add a new workflow plus a scheduled unpinned install for
+little benefit. If that early-warning signal is ever wanted, it must stay
+`contents: read` only — summary output, never issue creation or `git push`.


### PR DESCRIPTION
## Summary

Reworks issue #54 as a **doc-only, zero-write-permission, minimal change**. This is a redo of the now-closed **PR #82**, which used a weekly schedule + `issues: write` to auto-file drift issues.

### Why the redo

`packages/stripe/scripts/check-events.ts` diffs `StripeEventMap` against the **installed** Stripe SDK (`node_modules/stripe/.../Events.d.ts`). `stripe` is pinned to `^22.0.0` and locked in `pnpm-lock.yaml`, so a frozen install always resolves to the same SDK build.

Consequences:
- **The event map can only drift when the `stripe` dependency is bumped.** A weekly scheduled frozen install re-checks the *same* pinned version every time and can never detect anything new → the scheduled + auto-issue approach has effectively no signal.
- Bumps already arrive as **Dependabot PRs** (weekly `npm` updates in `.github/dependabot.yml`), and the existing permissionless `check-stripe-events` job (ci.yml, "case A") runs on those PRs — exactly the right place and time to surface drift.
- Granting an OSS CI workflow write scopes (`issues: write`, etc.) widens the supply-chain attack surface for no real benefit.

### What changed

- **`packages/stripe/MAINTAINING_STRIPE_EVENTMAP.md`** — replaced the tentative "CI Integration" suggestion with the adopted, final policy:
  - Case A `check-stripe-events` (push/PR, **no permissions**, fails on drift) is the drift-detection mechanism; it fires on the Dependabot `stripe` bump PR.
  - Stripe version pinning policy: devDependency `^22.0.0` / peerDependency `>=17.0.0`; bumps go through Dependabot and must not merge until `pnpm run check-events` is green.
  - Explicit rationale for **no scheduled run / no auto-issue / no write permissions**.

### What was intentionally NOT done

- **No new CI workflow and no automatic issue creation.** The existing `check-stripe-events` job is left untouched.
- **Optional read-only `stripe@latest` early-warning job: skipped.** Dependabot already runs weekly, so the lead time gained over the pin is marginal, and it would add a new workflow plus a scheduled unpinned install for little benefit. The doc records that if it is ever wanted, it must stay `contents: read` only (summary output, never issue creation or `git push`).
- **`dependabot.yml`: no change needed.** The `npm` ecosystem at directory `/` reads the root `pnpm-lock.yaml` and already covers `packages/stripe`.

### Validation

- `pnpm install` succeeded.
- `pnpm --filter @kotodayori/stripe run check-events` is green ("in sync", 260/260 events). The event map itself was not modified.

Closes #54

https://claude.ai/code/session_01VerdFL3t8r8XYFgHZxCsze

---
_Generated by [Claude Code](https://claude.ai/code/session_01VerdFL3t8r8XYFgHZxCsze)_