### PR TITLE
feat(ci): weekly read-only sentinel for upstream Stripe event additions (issue #54 redo)

### DIFF
--- a/.github/workflows/stripe-events-sync.yml
+++ b/.github/workflows/stripe-events-sync.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4.3.0
@@ -36,7 +38,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       # Upgrade stripe in-place on the runner (lockfile/package.json changes are
       # ephemeral — never committed back).  This is the whole point: we check

--- a/.github/workflows/stripe-events-sync.yml
+++ b/.github/workflows/stripe-events-sync.yml
@@ -1,0 +1,64 @@
+name: Stripe Events Sync (Weekly)
+
+# Runs weekly against stripe@latest to detect upstream additions before they
+# reach the pinned devDependency.  Job failure is the notification channel:
+# GitHub automatically emails repository admins when a scheduled workflow fails.
+#
+# This is a read-only sentinel — it never commits, never opens issues, and has
+# no write permissions.  See packages/stripe/MAINTAINING_STRIPE_EVENTMAP.md for
+# the two-system CI design.
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'  # Every Monday at 00:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-stripe-events-latest:
+    name: Check Stripe Events Sync (stripe@latest)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4.3.0
+        with:
+          version: 9.15.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      # Upgrade stripe in-place on the runner (lockfile/package.json changes are
+      # ephemeral — never committed back).  This is the whole point: we check
+      # against the *latest* published stripe, not the pinned devDependency.
+      - name: Update stripe to latest
+        run: pnpm --filter @kotodayori/stripe add -D stripe@latest
+
+      - name: Check Stripe Event Map sync against stripe@latest
+        run: |
+          output=$(pnpm --filter @kotodayori/stripe run check-events 2>&1)
+          exit_code=$?
+          echo "$output"
+          {
+            echo "## Stripe Events Sync Check"
+            echo ""
+            echo '```'
+            echo "$output"
+            echo '```'
+            if [ "$exit_code" -ne 0 ]; then
+              echo ""
+              echo "**Action required:** \`StripeEventMap\` in \`packages/stripe/src/index.ts\` is out of sync with the latest stripe SDK."
+              echo "See \`packages/stripe/MAINTAINING_STRIPE_EVENTMAP.md\` for update instructions."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit $exit_code

--- a/packages/stripe/MAINTAINING_STRIPE_EVENTMAP.md
+++ b/packages/stripe/MAINTAINING_STRIPE_EVENTMAP.md
@@ -14,12 +14,12 @@ Run the check script to detect missing or extra events:
 pnpm run check-events
 ```
 
-This script attempts to:
-1. Extract event names from our `StripeEventMap`
-2. Find event types exported by the Stripe SDK
-3. Compare the two lists
+This script:
+1. Extracts event names from `StripeEventMap`
+2. Reads event types exported by the installed Stripe SDK
+3. Reports mismatches and exits 1 if any are found
 
-**Note:** The script uses heuristics to convert PascalCase type names to dot.notation event names, so it may produce false positives.
+**Note:** The script uses heuristics to convert PascalCase type names to dot.notation event names, so it may produce false positives (see `check-events-exceptions.json`).
 
 ## Adding New Events
 
@@ -39,23 +39,60 @@ export type StripeEventMap = {
 4. Run `pnpm run check-events` to verify
 5. Run `pnpm test` to ensure types compile correctly
 
-## Stripe SDK Updates
+## stripe SDK Version Policy
 
-When updating the `stripe` package:
+- **devDependency**: `^22.0.0` — the pinned range used for local development and CI builds
+- **peerDependency**: `>=17.0.0` — the minimum version consumers must provide
+- **Bumping**: Upgrade via Dependabot PR or `pnpm update stripe` manually.
+  Before merging any stripe bump, confirm `pnpm run check-events` is green (the
+  CI `check-stripe-events` job in `ci.yml` enforces this automatically).
 
-1. Update the dependency: `pnpm update stripe`
-2. Run `pnpm run check-events` to detect any new events
-3. Add any missing events to `StripeEventMap`
-4. Run the test suite: `pnpm test`
+## CI Design: Two Complementary Systems
 
-## CI Integration
+Two GitHub Actions jobs guard `StripeEventMap` from different angles:
 
-Consider adding the check script to your CI pipeline:
+### Case A — PR/push blocker (`ci.yml` › `check-stripe-events`)
 
-```yaml
-# .github/workflows/ci.yml
-- name: Check Stripe events sync
-  run: pnpm run check-events
-```
+- **Trigger**: every push to `main`/`develop` and every PR against those branches
+- **stripe version used**: the pinned devDependency in `pnpm-lock.yaml` (`^22.0.0`)
+- **Purpose**: block merges that break sync with the *currently pinned* stripe
+- **Permissions**: none beyond the default read token
+- **Write access**: none — never commits or opens issues
 
-This will fail the build if the event map becomes out of sync with the SDK.
+This job ensures contributors cannot accidentally introduce a mismatch when
+they bump the `stripe` devDependency or edit `StripeEventMap`.
+
+### Case B — Weekly upstream sentinel (`.github/workflows/stripe-events-sync.yml`)
+
+- **Trigger**: `schedule` (every Monday 00:00 UTC) + `workflow_dispatch`
+- **stripe version used**: `stripe@latest` installed fresh on the runner each run
+- **Purpose**: detect new event types that Stripe shipped *upstream* before they
+  reach the pinned devDependency — an early-warning system independent of PRs
+- **Permissions**: `contents: read` only
+- **Write access**: none — never commits, never opens issues, never pushes
+
+**How failure is communicated**: when the job exits 1 (mismatch found), GitHub
+automatically emails the repository administrators. No `issues: write` permission
+or extra notification infrastructure is needed.
+
+The job also writes its output to `$GITHUB_STEP_SUMMARY` so the mismatch details
+are visible directly in the Actions run UI without needing to dig through logs.
+
+**Lockfile/package.json changes are ephemeral**: `pnpm add stripe@latest` runs
+on the runner and never gets committed back to the repository.
+
+### Why not combine them into one job?
+
+The two jobs serve different threat models:
+
+| | Case A (ci.yml) | Case B (sync.yml) |
+|---|---|---|
+| Trigger | PR / push | Weekly schedule |
+| stripe version | pinned (lockfile) | latest published |
+| Detects | regression from edits | upstream additions |
+| Blocking | yes (blocks merge) | no (async alert) |
+
+Using `stripe@latest` in CI would make PRs non-deterministic (a passing CI run
+today could fail tomorrow if Stripe publishes a new event overnight).  Keeping
+the two concerns separate maintains reproducible PR checks while still providing
+proactive upstream monitoring.

--- a/packages/stripe/MAINTAINING_STRIPE_EVENTMAP.md
+++ b/packages/stripe/MAINTAINING_STRIPE_EVENTMAP.md
@@ -39,7 +39,7 @@ export type StripeEventMap = {
 4. Run `pnpm run check-events` to verify
 5. Run `pnpm test` to ensure types compile correctly
 
-## stripe SDK Version Policy
+## Stripe SDK Version Policy
 
 - **devDependency**: `^22.0.0` — the pinned range used for local development and CI builds
 - **peerDependency**: `>=17.0.0` — the minimum version consumers must provide


### PR DESCRIPTION
## PR #82 の仕切り直し

PR #82 はクローズ、続く doc 修正 PR もメンテナに却下されました。
今回は「書き込み権限ゼロ・issue 自動起票なし」の設計に完全に切り替えて issue #54 を解決します。

---

## 何をするか

### 追加: `.github/workflows/stripe-events-sync.yml`

**目的**: Stripe が上流で新しい webhook event type を追加したことを、
リポジトリの pinned devDependency より先に検知する read-only な見張り。

**動作**:
1. 毎週月曜 00:00 UTC (`schedule`) + 手動 (`workflow_dispatch`) に起動
2. `pnpm install`（frozen lockfile なし）でベース依存を入れる
3. **`pnpm --filter @kotodayori/stripe add -D stripe@latest`** でランナー上の stripe だけ最新に差し替え（lockfile/package.json の変更はランナー内限り、コミットしない）
4. `pnpm --filter @kotodayori/stripe run check-events` を実行
5. ズレがあれば exit 1 → **ジョブ失敗 = GitHub が管理者へ自動メール** で通知

### 更新: `packages/stripe/MAINTAINING_STRIPE_EVENTMAP.md`

2 系統の CI 設計を明文化:

| | Case A (`ci.yml`) | Case B (今回追加) |
|---|---|---|
| トリガー | PR / push | 週次スケジュール |
| stripe バージョン | pinned (lockfile) | `stripe@latest` |
| 目的 | 編集による regression をブロック | 上流の新 event を先行検知 |
| マージブロック | あり | なし (非同期アラート) |

stripe devDep のバージョン固定方針 (`^22.0.0` / peerDep `>=17.0.0`) と
bump 時の運用手順も追記。

---

## なぜ前回の設計を捨てたか

| 廃止した要素 | 理由 |
|---|---|
| `issues: write` / issue 自動起票 | 書き込み権限は不要・過剰。ジョブ失敗通知で十分 |
| `pull_request_target` | フォークコード × 書き込みトークンの pwn-request リスク |
| git commit / push 自動化 | 書き込み権限不要設計と矛盾、メンテナへの却下理由でもある |
| mutable version タグ (`@v4`, `@v6`) | タグ書き換え攻撃（tj-actions インシデント参照）を防ぐため SHA pin に変更 |

---

## Action の SHA ピン

セキュリティ強化のため全サードパーティ Action を commit SHA で固定:

```
actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10   # v6.0.3
pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4.3.0
actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
```

---

## 検証

- `pnpm --filter @kotodayori/stripe run check-events` → ✅ in sync (260 events)
- `StripeEventMap` 自体は変更なし
- `ci.yml` の既存 `check-stripe-events` ジョブは手付かずで残存

Closes #54

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYmHZsZqS2h9vBJ3QYcFr1)_